### PR TITLE
Update `inkwell` to 0.4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,43 +12,43 @@ jobs:
     strategy:
       matrix:
         os:
-        - runner: ubuntu-latest
-          name: linux
-        - runner: macos-latest
-          name: apple
-        llvm: [15, 16]
+          - runner: ubuntu-latest
+            name: linux
+          - runner: macos-latest
+            name: apple
+        llvm: [15, 16, 17]
         profile: [debug, release]
     runs-on: "${{ matrix.os.runner }}"
     if: "${{ !cancelled() }}"
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Install LLVM (Homebrew)
-      if: matrix.os.runner == 'macos-latest' && matrix.llvm >= 16
-      run: |
-        brew install llvm@${{ matrix.llvm }}
-        echo /usr/local/opt/llvm@${{ matrix.llvm }}/bin >> $GITHUB_PATH
-    - name: Install LLVM (Action)
-      if: matrix.os.runner != 'macos-latest' || matrix.llvm <= 15
-      uses: KyleMayes/install-llvm-action@v1
-      with:
-        version: "${{ matrix.llvm }}.0"
-    - name: Cache Build Outputs
-      uses: actions/cache@v3
-      with:
-        key: build-${{ matrix.os.runner }} -${{ github.ref_name }}-${{ hashFiles('**/src') }}
-        restore-keys: |
-          build-${{ matrix.os.runner }}-${{ github.ref_name }}-
-          build-${{ matrix.os.runner }}
-        path: |
-          Cargo.lock
-          target/
-    - name: Build
-      run: "cargo build --profile ${{ matrix.profile == 'debug' && 'dev' || matrix.profile }} --no-default-features -F build-default,llvm-${{ matrix.llvm }}"
-    - name: Compress
-      run: "gzip -fN9 'target/${{ matrix.profile }}/co'"
-    - name: Upload
-      uses: actions/upload-artifact@v3
-      with:
-        name: "co-${{ matrix.profile }}-${{ matrix.os.name }}-${{ matrix.link }}-${{ matrix.llvm }}.gz"
-        path: "target/${{ matrix.profile }}/co.gz"
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install LLVM (Homebrew)
+        if: matrix.os.runner == 'macos-latest' && matrix.llvm >= 16
+        run: |
+          brew install llvm@${{ matrix.llvm }}
+          echo /usr/local/opt/llvm@${{ matrix.llvm }}/bin >> $GITHUB_PATH
+      - name: Install LLVM (Action)
+        if: matrix.os.runner != 'macos-latest' || matrix.llvm <= 15
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "${{ matrix.llvm }}.0"
+      - name: Cache Build Outputs
+        uses: actions/cache@v3
+        with:
+          key: build-${{ matrix.os.runner }} -${{ github.ref_name }}-${{ hashFiles('**/src') }}
+          restore-keys: |
+            build-${{ matrix.os.runner }}-${{ github.ref_name }}-
+            build-${{ matrix.os.runner }}
+          path: |
+            Cargo.lock
+            target/
+      - name: Build
+        run: "cargo build --profile ${{ matrix.profile == 'debug' && 'dev' || matrix.profile }}"
+      - name: Compress
+        run: "gzip -fN9 'target/${{ matrix.profile }}/co'"
+      - name: Upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: "co-${{ matrix.profile }}-${{ matrix.os.name }}-llvm${{ matrix.llvm }}.gz"
+          path: "target/${{ matrix.profile }}/co.gz"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,53 +15,49 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Install LLVM
-      uses: KyleMayes/install-llvm-action@v1
-      with:
-        version: "16.0"
-    - name: Cache Build Outputs
-      uses: actions/cache@v3
-      with:
-        key: test-${{ github.ref_name }}-${{ hashFiles('**/src') }}
-        restore-keys: |
-          test-${{ github.ref_name }}-
-          test-
-        path: |
-          Cargo.lock
-          target/
-    - name: Run Clippy
-      run: cargo clippy
-      env:
-        RUSTFLAGS: "-Dwarnings"
-  
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Cache Build Outputs
+        uses: actions/cache@v3
+        with:
+          key: test-${{ github.ref_name }}-${{ hashFiles('**/src') }}
+          restore-keys: |
+            test-${{ github.ref_name }}-
+            test-
+          path: |
+            Cargo.lock
+            target/
+      - name: Run Clippy
+        run: cargo clippy
+        env:
+          RUSTFLAGS: "-Dwarnings"
+
   test:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Install LLVM
-      uses: KyleMayes/install-llvm-action@v1
-      with:
-        version: "16.0"
-    - name: Cache Build Outputs
-      uses: actions/cache@v3
-      with:
-        key: test-${{ github.ref_name }}-${{ hashFiles('**/src') }}
-        restore-keys: |
-          test-${{ github.ref_name }}-
-          test-
-        path: |
-          Cargo.lock
-          target/
-    - name: Run Cargo Test
-      run: cargo test
-  
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install LLVM
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "17.0"
+      - name: Cache Build Outputs
+        uses: actions/cache@v3
+        with:
+          key: test-${{ github.ref_name }}-${{ hashFiles('**/src') }}
+          restore-keys: |
+            test-${{ github.ref_name }}-
+            test-
+          path: |
+            Cargo.lock
+            target/
+      - name: Run Cargo Test
+        run: cargo test
+
   fmt:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Run Cargo Formatter
-      run: cargo fmt --check
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run Cargo Formatter
+        run: cargo fmt --check

--- a/cobalt-ast/src/ast/flow.rs
+++ b/cobalt-ast/src/ast/flow.rs
@@ -76,7 +76,7 @@ impl<'src> AST<'src> for IfAST<'src> {
                     ctx.builder.position_at_end(mb);
                     Value::new(
                         if let Some(llt) = ty.llvm_type(ctx) {
-                            let phi = ctx.builder.build_phi(llt, "");
+                            let phi = ctx.builder.build_phi(llt, "").unwrap();
                             if let Some(v) = if_true.value(ctx) {
                                 phi.add_incoming(&[(&v, itb)]);
                             }

--- a/cobalt-ast/src/ast/flow.rs
+++ b/cobalt-ast/src/ast/flow.rs
@@ -55,7 +55,7 @@ impl<'src> AST<'src> for IfAST<'src> {
                 let itb = ctx.context.append_basic_block(f, "if_true");
                 let ifb = ctx.context.append_basic_block(f, "if_false");
                 let mb = ctx.context.append_basic_block(f, "merge");
-                ctx.builder.build_conditional_branch(v, itb, ifb);
+                ctx.builder.build_conditional_branch(v, itb, ifb).unwrap();
                 ctx.builder.position_at_end(itb);
                 let if_true = self.if_true.codegen(ctx, errs);
                 ctx.builder.position_at_end(ifb);
@@ -66,13 +66,13 @@ impl<'src> AST<'src> for IfAST<'src> {
                         errs.push(e);
                         Value::error().with_loc(self.if_true.loc())
                     });
-                    ctx.builder.build_unconditional_branch(mb);
+                    ctx.builder.build_unconditional_branch(mb).unwrap();
                     ctx.builder.position_at_end(ifb);
                     let if_false = if_false.impl_convert((ty, None), ctx).unwrap_or_else(|e| {
                         errs.push(e);
                         Value::error().with_loc(self.if_false.loc())
                     });
-                    ctx.builder.build_unconditional_branch(mb);
+                    ctx.builder.build_unconditional_branch(mb).unwrap();
                     ctx.builder.position_at_end(mb);
                     Value::new(
                         if let Some(llt) = ty.llvm_type(ctx) {
@@ -100,9 +100,9 @@ impl<'src> AST<'src> for IfAST<'src> {
                     )
                 } else {
                     ctx.builder.position_at_end(itb);
-                    ctx.builder.build_unconditional_branch(mb);
+                    ctx.builder.build_unconditional_branch(mb).unwrap();
                     ctx.builder.position_at_end(ifb);
-                    ctx.builder.build_unconditional_branch(mb);
+                    ctx.builder.build_unconditional_branch(mb).unwrap();
                     ctx.builder.position_at_end(mb);
                     Value::null()
                 }
@@ -159,7 +159,7 @@ impl<'src> AST<'src> for WhileAST<'src> {
             let cond = ctx.context.append_basic_block(f, "cond");
             let body = ctx.context.append_basic_block(f, "body");
             let exit = ctx.context.append_basic_block(f, "exit");
-            ctx.builder.build_unconditional_branch(cond);
+            ctx.builder.build_unconditional_branch(cond).unwrap();
             ctx.builder.position_at_end(cond);
             let c = self.cond.codegen(ctx, errs);
             let val = c
@@ -174,10 +174,11 @@ impl<'src> AST<'src> for WhileAST<'src> {
                 .value(ctx)
                 .unwrap_or(ctx.context.bool_type().const_int(0, false).into());
             ctx.builder
-                .build_conditional_branch(val.into_int_value(), body, exit);
+                .build_conditional_branch(val.into_int_value(), body, exit)
+                .unwrap();
             ctx.builder.position_at_end(body);
             self.body.codegen(ctx, errs);
-            ctx.builder.build_unconditional_branch(cond);
+            ctx.builder.build_unconditional_branch(cond).unwrap();
             ctx.builder.position_at_end(exit);
             Value::null()
         } else {

--- a/cobalt-ast/src/ast/funcs.rs
+++ b/cobalt-ast/src/ast/funcs.rs
@@ -1122,7 +1122,7 @@ impl<'src> AST<'src> for FnDefAST<'src> {
                                             .builder
                                             .build_alloca(param.get_type(), name)
                                             .unwrap();
-                                        ctx.builder.build_store(a, val.comp_val.unwrap());
+                                        ctx.builder.build_store(a, val.comp_val.unwrap()).unwrap();
                                         val.comp_val = Some(a.into());
                                         val.data_type = types::Mut::new(val.data_type);
                                     }
@@ -1210,14 +1210,16 @@ impl<'src> AST<'src> for FnDefAST<'src> {
                                 }
                             }
                         }
-                        ctx.builder.build_return(Some(
-                            &body
-                                .impl_convert((ret, Some(self.ret.loc())), ctx)
-                                .map_err(|e| errs.push(e))
-                                .ok()
-                                .and_then(|v| v.value(ctx))
-                                .unwrap_or(llt.const_zero()),
-                        ));
+                        ctx.builder
+                            .build_return(Some(
+                                &body
+                                    .impl_convert((ret, Some(self.ret.loc())), ctx)
+                                    .map_err(|e| errs.push(e))
+                                    .ok()
+                                    .and_then(|v| v.value(ctx))
+                                    .unwrap_or(llt.const_zero()),
+                            ))
+                            .unwrap();
                         hoist_allocas(&ctx.builder);
                         let mut b = ctx.moves.borrow_mut();
                         b.0.retain(|v| v.name.1 < ctx.lex_scope.get());
@@ -1412,7 +1414,7 @@ impl<'src> AST<'src> for FnDefAST<'src> {
                                             .builder
                                             .build_alloca(param.get_type(), name)
                                             .unwrap();
-                                        ctx.builder.build_store(a, val.comp_val.unwrap());
+                                        ctx.builder.build_store(a, val.comp_val.unwrap()).unwrap();
                                         val.comp_val = Some(a.into());
                                         val.data_type = types::Mut::new(val.data_type);
                                     }
@@ -1500,7 +1502,7 @@ impl<'src> AST<'src> for FnDefAST<'src> {
                                 }
                             }
                         }
-                        ctx.builder.build_return(None);
+                        ctx.builder.build_return(None).unwrap();
                         hoist_allocas(&ctx.builder);
                         let mut b = ctx.moves.borrow_mut();
                         b.0.retain(|v| v.name.1 < ctx.lex_scope.get());

--- a/cobalt-ast/src/ast/funcs.rs
+++ b/cobalt-ast/src/ast/funcs.rs
@@ -1118,7 +1118,10 @@ impl<'src> AST<'src> for FnDefAST<'src> {
                                     param.set_name(name);
                                     let mut val = Value::compiled(param, ty);
                                     if pt == ParamType::Mutable {
-                                        let a = ctx.builder.build_alloca(param.get_type(), name);
+                                        let a = ctx
+                                            .builder
+                                            .build_alloca(param.get_type(), name)
+                                            .unwrap();
                                         ctx.builder.build_store(a, val.comp_val.unwrap());
                                         val.comp_val = Some(a.into());
                                         val.data_type = types::Mut::new(val.data_type);
@@ -1405,7 +1408,10 @@ impl<'src> AST<'src> for FnDefAST<'src> {
                                     param.set_name(name);
                                     let mut val = Value::compiled(param, ty);
                                     if pt == ParamType::Mutable {
-                                        let a = ctx.builder.build_alloca(param.get_type(), name);
+                                        let a = ctx
+                                            .builder
+                                            .build_alloca(param.get_type(), name)
+                                            .unwrap();
                                         ctx.builder.build_store(a, val.comp_val.unwrap());
                                         val.comp_val = Some(a.into());
                                         val.data_type = types::Mut::new(val.data_type);

--- a/cobalt-ast/src/ast/literals.rs
+++ b/cobalt-ast/src/ast/literals.rs
@@ -424,6 +424,7 @@ impl<'src> AST<'src> for ArrayLiteralAST<'src> {
                         ctx.builder
                             .build_insert_value(val, v.comp_val?, n as _, "")
                             .map(|v| v.into_array_value())
+                            .ok()
                     })
                     .map(Into::into)
             } else {
@@ -506,6 +507,7 @@ impl<'src> AST<'src> for TupleLiteralAST<'src> {
                         .build_insert_value(sv, v, n as u32, "")
                         .map(|x| x.into_struct_value())
                 })
+                .ok()
                 .map(From::from);
         };
         if inters.iter().all(Option::is_some) {

--- a/cobalt-ast/src/ast/misc.rs
+++ b/cobalt-ast/src/ast/misc.rs
@@ -141,9 +141,11 @@ impl<'src> AST<'src> for BitCastAST<'src> {
                 || cty.is_array_type()
                 || cty.is_struct_type()
             {
-                ctx.builder.build_load(llt, val.addr(ctx).unwrap(), "")
+                ctx.builder
+                    .build_load(llt, val.addr(ctx).unwrap(), "")
+                    .unwrap()
             } else {
-                ctx.builder.build_bitcast(ctval, llt, "")
+                ctx.builder.build_bitcast(ctval, llt, "").unwrap()
             };
             cfg::mark_move(
                 &val,

--- a/cobalt-ast/src/ast/ops.rs
+++ b/cobalt-ast/src/ast/ops.rs
@@ -58,7 +58,7 @@ impl<'src> AST<'src> for BinOpAST<'src> {
                         (
                             if let (Some(val), Some(ifv)) = (rhs.value(ctx), rhv.value(ctx)) {
                                 let llt = val.get_type();
-                                let phi = ctx.builder.build_phi(llt, "");
+                                let phi = ctx.builder.build_phi(llt, "").unwrap();
                                 phi.add_incoming(&[(&val, ab), (&ifv, bb)]);
                                 Some(phi.as_basic_value())
                             } else {
@@ -79,7 +79,7 @@ impl<'src> AST<'src> for BinOpAST<'src> {
                             Ok(rhv) => (
                                 if let Some(val) = rhv.value(ctx) {
                                     let llt = ctx.context.bool_type();
-                                    let phi = ctx.builder.build_phi(llt, "");
+                                    let phi = ctx.builder.build_phi(llt, "").unwrap();
                                     phi.add_incoming(&[(&val, ab), (&llt.const_zero(), bb)]);
                                     Some(phi.as_basic_value())
                                 } else {
@@ -135,7 +135,7 @@ impl<'src> AST<'src> for BinOpAST<'src> {
                         (
                             if let (Some(val), Some(ifv)) = (rhs.value(ctx), rhv.value(ctx)) {
                                 let llt = val.get_type();
-                                let phi = ctx.builder.build_phi(llt, "");
+                                let phi = ctx.builder.build_phi(llt, "").unwrap();
                                 phi.add_incoming(&[(&val, ab), (&ifv, bb)]);
                                 Some(phi.as_basic_value())
                             } else {
@@ -156,7 +156,7 @@ impl<'src> AST<'src> for BinOpAST<'src> {
                             Ok(rhv) => (
                                 if let Some(val) = rhv.value(ctx) {
                                     let llt = ctx.context.bool_type();
-                                    let phi = ctx.builder.build_phi(llt, "");
+                                    let phi = ctx.builder.build_phi(llt, "").unwrap();
                                     phi.add_incoming(&[(&val, ab), (&llt.const_int(1, false), bb)]);
                                     Some(phi.as_basic_value())
                                 } else {

--- a/cobalt-ast/src/ast/ops.rs
+++ b/cobalt-ast/src/ast/ops.rs
@@ -42,10 +42,10 @@ impl<'src> AST<'src> for BinOpAST<'src> {
                     let f = bb.get_parent().unwrap();
                     let ab = ctx.context.append_basic_block(f, "active");
                     let mb = ctx.context.append_basic_block(f, "merge");
-                    ctx.builder.build_conditional_branch(val, ab, mb);
+                    ctx.builder.build_conditional_branch(val, ab, mb).unwrap();
                     ctx.builder.position_at_end(ab);
                     let mut rhs = self.rhs.codegen(ctx, errs);
-                    ctx.builder.build_unconditional_branch(mb);
+                    ctx.builder.build_unconditional_branch(mb).unwrap();
                     ctx.builder.position_at_end(mb);
                     if rhs.data_type.kind() == types::IntLiteral::KIND {
                         rhs.data_type = types::Int::unsigned(64);
@@ -119,10 +119,10 @@ impl<'src> AST<'src> for BinOpAST<'src> {
                     let f = bb.get_parent().unwrap();
                     let ab = ctx.context.append_basic_block(f, "active");
                     let mb = ctx.context.append_basic_block(f, "merge");
-                    ctx.builder.build_conditional_branch(val, mb, ab);
+                    ctx.builder.build_conditional_branch(val, mb, ab).unwrap();
                     ctx.builder.position_at_end(ab);
                     let mut rhs = self.rhs.codegen(ctx, errs);
-                    ctx.builder.build_unconditional_branch(mb);
+                    ctx.builder.build_unconditional_branch(mb).unwrap();
                     ctx.builder.position_at_end(mb);
                     if rhs.data_type.kind() == types::IntLiteral::KIND {
                         rhs.data_type = types::Int::signed(64);

--- a/cobalt-ast/src/ast/vars.rs
+++ b/cobalt-ast/src/ast/vars.rs
@@ -839,7 +839,8 @@ impl<'src> AST<'src> for VarDefAST<'src> {
                 let a = val.addr(ctx).unwrap_or_else(|| {
                     let a = ctx
                         .builder
-                        .build_alloca(t, self.name.ids.last().map_or("", |(x, _)| &**x));
+                        .build_alloca(t, self.name.ids.last().map_or("", |(x, _)| &**x))
+                        .unwrap();
                     ctx.builder.build_store(a, v);
                     a
                 });

--- a/cobalt-ast/src/ast/vars.rs
+++ b/cobalt-ast/src/ast/vars.rs
@@ -640,8 +640,8 @@ impl<'src> AST<'src> for VarDefAST<'src> {
                         ctx.restore_scope(old_scope);
                         if let Some(v) = val.value(ctx) {
                             val.inter_val = None;
-                            ctx.builder.build_store(gv.as_pointer_value(), v);
-                            ctx.builder.build_return(None);
+                            ctx.builder.build_store(gv.as_pointer_value(), v).unwrap();
+                            ctx.builder.build_return(None).unwrap();
                             hoist_allocas(&ctx.builder);
                             if let Some(bb) = old_ip {
                                 ctx.builder.position_at_end(bb);
@@ -841,7 +841,7 @@ impl<'src> AST<'src> for VarDefAST<'src> {
                         .builder
                         .build_alloca(t, self.name.ids.last().map_or("", |(x, _)| &**x))
                         .unwrap();
-                    ctx.builder.build_store(a, v);
+                    ctx.builder.build_store(a, v).unwrap();
                     a
                 });
                 let mut val = Value::new(

--- a/cobalt-ast/src/cfg.rs
+++ b/cobalt-ast/src/cfg.rs
@@ -1028,11 +1028,13 @@ impl<'a, 'src, 'ctx> Cfg<'a, 'src, 'ctx> {
                         let db = ctx
                             .context
                             .append_basic_block(f, &format!("dtor.{}.{}", m.name.0, m.name.1));
-                        ctx.builder.build_conditional_branch(c, next_block, db);
+                        ctx.builder
+                            .build_conditional_branch(c, next_block, db)
+                            .unwrap();
                         next.erase_from_basic_block();
                         ctx.builder.position_at_end(db);
                         ctx.lookup(&m.name.0, false).unwrap().0.ins_dtor(ctx);
-                        ctx.builder.build_unconditional_branch(next_block);
+                        ctx.builder.build_unconditional_branch(next_block).unwrap();
                         ctx.builder.position_at_end(next_block);
                     }
                 }
@@ -1054,10 +1056,10 @@ impl<'a, 'src, 'ctx> Cfg<'a, 'src, 'ctx> {
                                 .context
                                 .append_basic_block(f, &format!("dtor.{n}.{scope}"));
                             let mb = ctx.context.append_basic_block(f, "merge");
-                            ctx.builder.build_conditional_branch(c, mb, db);
+                            ctx.builder.build_conditional_branch(c, mb, db).unwrap();
                             ctx.builder.position_at_end(db);
                             v.0.ins_dtor(ctx);
-                            ctx.builder.build_unconditional_branch(mb);
+                            ctx.builder.build_unconditional_branch(mb).unwrap();
                             ctx.builder.position_at_end(mb);
                         }
                     }

--- a/cobalt-ast/src/cfg.rs
+++ b/cobalt-ast/src/cfg.rs
@@ -575,17 +575,16 @@ impl<'a, 'src, 'ctx> Cfg<'a, 'src, 'ctx> {
                             let mut val = match blocks[prev].reached.get_zero_extended_constant() {
                                 Some(0) => false_,
                                 Some(1) => c.into_int_value(),
-                                _ => ctx.builder.build_and(
-                                    blocks[prev].reached,
-                                    c.into_int_value(),
-                                    "",
-                                ),
+                                _ => ctx
+                                    .builder
+                                    .build_and(blocks[prev].reached, c.into_int_value(), "")
+                                    .unwrap(),
                             };
                             if !pos {
                                 val = match val.get_zero_extended_constant() {
                                     Some(0) => true_,
                                     Some(1) => false_,
-                                    _ => ctx.builder.build_not(val, ""),
+                                    _ => ctx.builder.build_not(val, "").unwrap(),
                                 };
                             }
                             val
@@ -972,7 +971,7 @@ impl<'a, 'src, 'ctx> Cfg<'a, 'src, 'ctx> {
                                     (Some(0), _) => block.reached,
                                     (_, Some(0)) => out,
                                     (Some(1), _) | (_, Some(1)) => true_,
-                                    _ => ctx.builder.build_or(out, block.reached, ""),
+                                    _ => ctx.builder.build_or(out, block.reached, "").unwrap(),
                                 }
                             }
                             Some(true) => {}

--- a/cobalt-ast/src/intrinsics/misc.rs
+++ b/cobalt-ast/src/intrinsics/misc.rs
@@ -222,7 +222,7 @@ fn alloca<'src, 'ctx>(
         if let Some(ty) = ty {
             if let Some(llt) = ty.llvm_type(ctx) {
                 Ok(Value::compiled(
-                    ctx.builder.build_alloca(llt, "").into(),
+                    ctx.builder.build_alloca(llt, "").unwrap().into(),
                     types::Pointer::new(types::Mut::new(ty)),
                 ))
             } else {
@@ -241,11 +241,10 @@ fn alloca<'src, 'ctx>(
             let arg = arg.decay(ctx);
             if arg.data_type.is::<types::Int>() {
                 if let Some(out) = &mut out {
-                    *out = ctx.builder.build_int_mul(
-                        *out,
-                        arg.value(ctx).unwrap().into_int_value(),
-                        "",
-                    );
+                    *out = ctx
+                        .builder
+                        .build_int_mul(*out, arg.value(ctx).unwrap().into_int_value(), "")
+                        .unwrap();
                 } else {
                     out = Some(arg.value(ctx).unwrap().into_int_value());
                 }
@@ -271,6 +270,7 @@ fn alloca<'src, 'ctx>(
                 } else {
                     ctx.builder.build_alloca(llt, "")
                 }
+                .unwrap()
                 .into(),
                 types::Pointer::new(types::Mut::new(ty)),
             ))

--- a/cobalt-ast/src/types/agg.rs
+++ b/cobalt-ast/src/types/agg.rs
@@ -611,7 +611,7 @@ impl Type for SizedArray {
         let at = self.llvm_type(ctx).unwrap();
         let bb = ctx.context.append_basic_block(f, "arr.dtor.loop");
         let ex = ctx.context.append_basic_block(f, "arr.dtor.exit");
-        ctx.builder.build_unconditional_branch(bb);
+        ctx.builder.build_unconditional_branch(bb).unwrap();
         ctx.builder.position_at_end(bb);
         let i64t = ctx.context.i64_type();
         let phi = ctx.builder.build_phi(i64t, "").unwrap();

--- a/cobalt-ast/src/types/custom.rs
+++ b/cobalt-ast/src/types/custom.rs
@@ -283,7 +283,7 @@ impl Type for Custom {
         let info = &borrow[keys.3];
         if let Some(pv) = val.addr(ctx) {
             if let Some(fv) = info.dtor {
-                ctx.builder.build_call(fv, &[pv.into()], "");
+                ctx.builder.build_call(fv, &[pv.into()], "").unwrap();
             } else if !info.no_auto_drop {
                 Value {
                     data_type: self.base(),

--- a/cobalt-ast/src/types/float.rs
+++ b/cobalt-ast/src/types/float.rs
@@ -1244,7 +1244,7 @@ impl Type for Float {
                         .builder
                         .build_float_add(v1, ft.const_float(1.0), "")
                         .unwrap();
-                    ctx.builder.build_store(pv, v2);
+                    ctx.builder.build_store(pv, v2).unwrap();
                     val.comp_val
                 } else {
                     None
@@ -1264,7 +1264,7 @@ impl Type for Float {
                         .builder
                         .build_float_sub(v1, ft.const_float(1.0), "")
                         .unwrap();
-                    ctx.builder.build_store(pv, v2);
+                    ctx.builder.build_store(pv, v2).unwrap();
                     val.comp_val
                 } else {
                     None
@@ -1313,7 +1313,7 @@ impl Type for Float {
                                     .unwrap()
                                     .into_float_value();
                                 let v2 = ctx.builder.build_float_add(v1, rv, "").unwrap();
-                                ctx.builder.build_store(lv, v2);
+                                ctx.builder.build_store(lv, v2).unwrap();
                             }
                             "-=" => {
                                 let v1 = ctx
@@ -1322,7 +1322,7 @@ impl Type for Float {
                                     .unwrap()
                                     .into_float_value();
                                 let v2 = ctx.builder.build_float_sub(v1, rv, "").unwrap();
-                                ctx.builder.build_store(lv, v2);
+                                ctx.builder.build_store(lv, v2).unwrap();
                             }
                             "*=" => {
                                 let v1 = ctx
@@ -1331,7 +1331,7 @@ impl Type for Float {
                                     .unwrap()
                                     .into_float_value();
                                 let v2 = ctx.builder.build_float_mul(v1, rv, "").unwrap();
-                                ctx.builder.build_store(lv, v2);
+                                ctx.builder.build_store(lv, v2).unwrap();
                             }
                             "/=" => {
                                 let v1 = ctx
@@ -1340,7 +1340,7 @@ impl Type for Float {
                                     .unwrap()
                                     .into_float_value();
                                 let v2 = ctx.builder.build_float_div(v1, rv, "").unwrap();
-                                ctx.builder.build_store(lv, v2);
+                                ctx.builder.build_store(lv, v2).unwrap();
                             }
                             _ => return Err(invalid_binop(&lhs, &rhs, op.0, op.1)),
                         }
@@ -1380,7 +1380,7 @@ impl Type for Float {
                                     .unwrap()
                                     .into_float_value();
                                 let v2 = ctx.builder.build_float_add(v1, rv, "").unwrap();
-                                ctx.builder.build_store(lv, v2);
+                                ctx.builder.build_store(lv, v2).unwrap();
                             }
                             "-=" => {
                                 let v1 = ctx
@@ -1389,7 +1389,7 @@ impl Type for Float {
                                     .unwrap()
                                     .into_float_value();
                                 let v2 = ctx.builder.build_float_sub(v1, rv, "").unwrap();
-                                ctx.builder.build_store(lv, v2);
+                                ctx.builder.build_store(lv, v2).unwrap();
                             }
                             "*=" => {
                                 let v1 = ctx
@@ -1398,7 +1398,7 @@ impl Type for Float {
                                     .unwrap()
                                     .into_float_value();
                                 let v2 = ctx.builder.build_float_mul(v1, rv, "").unwrap();
-                                ctx.builder.build_store(lv, v2);
+                                ctx.builder.build_store(lv, v2).unwrap();
                             }
                             "/=" => {
                                 let v1 = ctx
@@ -1407,7 +1407,7 @@ impl Type for Float {
                                     .unwrap()
                                     .into_float_value();
                                 let v2 = ctx.builder.build_float_div(v1, rv, "").unwrap();
-                                ctx.builder.build_store(lv, v2);
+                                ctx.builder.build_store(lv, v2).unwrap();
                             }
                             _ => return Err(invalid_binop(&lhs, &rhs, op.0, op.1)),
                         }
@@ -1441,7 +1441,7 @@ impl Type for Float {
                                     .unwrap()
                                     .into_float_value();
                                 let v2 = ctx.builder.build_float_add(v1, rv, "").unwrap();
-                                ctx.builder.build_store(lv, v2);
+                                ctx.builder.build_store(lv, v2).unwrap();
                             }
                             "-=" => {
                                 let v1 = ctx
@@ -1450,7 +1450,7 @@ impl Type for Float {
                                     .unwrap()
                                     .into_float_value();
                                 let v2 = ctx.builder.build_float_sub(v1, rv, "").unwrap();
-                                ctx.builder.build_store(lv, v2);
+                                ctx.builder.build_store(lv, v2).unwrap();
                             }
                             "*=" => {
                                 let v1 = ctx
@@ -1459,7 +1459,7 @@ impl Type for Float {
                                     .unwrap()
                                     .into_float_value();
                                 let v2 = ctx.builder.build_float_mul(v1, rv, "").unwrap();
-                                ctx.builder.build_store(lv, v2);
+                                ctx.builder.build_store(lv, v2).unwrap();
                             }
                             "/=" => {
                                 let v1 = ctx
@@ -1468,7 +1468,7 @@ impl Type for Float {
                                     .unwrap()
                                     .into_float_value();
                                 let v2 = ctx.builder.build_float_div(v1, rv, "").unwrap();
-                                ctx.builder.build_store(lv, v2);
+                                ctx.builder.build_store(lv, v2).unwrap();
                             }
                             _ => return Err(invalid_binop(&lhs, &rhs, op.0, op.1)),
                         }

--- a/cobalt-ast/src/types/float.rs
+++ b/cobalt-ast/src/types/float.rs
@@ -95,15 +95,14 @@ impl Type for Float {
                         if self.kind() == ty.kind() {
                             Some(v.into())
                         } else {
-                            Some(
-                                ctx.builder
-                                    .build_float_ext(
-                                        v,
-                                        ty.llvm_type(ctx).unwrap().into_float_type(),
-                                        "",
-                                    )
-                                    .into(),
-                            )
+                            ctx.builder
+                                .build_float_ext(
+                                    v,
+                                    ty.llvm_type(ctx).unwrap().into_float_type(),
+                                    "",
+                                )
+                                .ok()
+                                .map(From::from)
                         }
                     } else {
                         None
@@ -127,8 +126,14 @@ impl Type for Float {
                     let ft = ty.llvm_type(ctx).unwrap().into_float_type();
                     use std::cmp::Ordering;
                     match ty.kind().cmp(&self.kind()) {
-                        Ordering::Greater => Some(ctx.builder.build_float_ext(v, ft, "").into()),
-                        Ordering::Less => Some(ctx.builder.build_float_trunc(v, ft, "").into()),
+                        Ordering::Greater => {
+                            ctx.builder.build_float_ext(v, ft, "").ok().map(From::from)
+                        }
+                        Ordering::Less => ctx
+                            .builder
+                            .build_float_trunc(v, ft, "")
+                            .ok()
+                            .map(From::from),
                         Ordering::Equal => Some(v.into()),
                     }
                 } else {
@@ -142,9 +147,15 @@ impl Type for Float {
                 if let Some(BasicValueEnum::FloatValue(v)) = val.comp_val {
                     let it = ty.llvm_type(ctx).unwrap().into_int_type();
                     if ty.is_signed() {
-                        Some(ctx.builder.build_float_to_signed_int(v, it, "").into())
+                        ctx.builder
+                            .build_float_to_signed_int(v, it, "")
+                            .ok()
+                            .map(From::from)
                     } else {
-                        Some(ctx.builder.build_float_to_unsigned_int(v, it, "").into())
+                        ctx.builder
+                            .build_float_to_unsigned_int(v, it, "")
+                            .ok()
+                            .map(From::from)
                     }
                 } else {
                     None
@@ -172,7 +183,7 @@ impl Type for Float {
             "+" => Ok(val),
             "-" => Ok(Value {
                 comp_val: if let Some(BasicValueEnum::FloatValue(v)) = val.value(ctx) {
-                    Some(ctx.builder.build_float_neg(v, "").into())
+                    ctx.builder.build_float_neg(v, "").ok().map(From::from)
                 } else {
                     None
                 },
@@ -236,7 +247,8 @@ impl Type for Float {
                                     ctx.builder.build_signed_int_to_float(v, ft, "")
                                 } else {
                                     ctx.builder.build_unsigned_int_to_float(v, ft, "")
-                                },
+                                }
+                                .unwrap(),
                             )
                         } else {
                             None
@@ -246,7 +258,7 @@ impl Type for Float {
                                 if let (Some(BasicValueEnum::FloatValue(l)), Some(r)) =
                                     (lhs.value(ctx), v)
                                 {
-                                    Some(ctx.builder.build_float_add(l, r, "").into())
+                                    ctx.builder.build_float_add(l, r, "").ok().map(From::from)
                                 } else {
                                     None
                                 },
@@ -263,7 +275,7 @@ impl Type for Float {
                                 if let (Some(BasicValueEnum::FloatValue(l)), Some(r)) =
                                     (lhs.value(ctx), v)
                                 {
-                                    Some(ctx.builder.build_float_sub(l, r, "").into())
+                                    ctx.builder.build_float_sub(l, r, "").ok().map(From::from)
                                 } else {
                                     None
                                 },
@@ -280,7 +292,7 @@ impl Type for Float {
                                 if let (Some(BasicValueEnum::FloatValue(l)), Some(r)) =
                                     (lhs.value(ctx), v)
                                 {
-                                    Some(ctx.builder.build_float_mul(l, r, "").into())
+                                    ctx.builder.build_float_mul(l, r, "").ok().map(From::from)
                                 } else {
                                     None
                                 },
@@ -297,7 +309,7 @@ impl Type for Float {
                                 if let (Some(BasicValueEnum::FloatValue(l)), Some(r)) =
                                     (lhs.value(ctx), v)
                                 {
-                                    Some(ctx.builder.build_float_div(l, r, "").into())
+                                    ctx.builder.build_float_div(l, r, "").ok().map(From::from)
                                 } else {
                                     None
                                 },
@@ -314,7 +326,10 @@ impl Type for Float {
                                 if let (Some(BasicValueEnum::FloatValue(l)), Some(r)) =
                                     (lhs.value(ctx), v)
                                 {
-                                    Some(ctx.builder.build_float_compare(OLT, l, r, "").into())
+                                    ctx.builder
+                                        .build_float_compare(OLT, l, r, "")
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -331,7 +346,10 @@ impl Type for Float {
                                 if let (Some(BasicValueEnum::FloatValue(l)), Some(r)) =
                                     (lhs.value(ctx), v)
                                 {
-                                    Some(ctx.builder.build_float_compare(OGT, l, r, "").into())
+                                    ctx.builder
+                                        .build_float_compare(OGT, l, r, "")
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -348,7 +366,10 @@ impl Type for Float {
                                 if let (Some(BasicValueEnum::FloatValue(l)), Some(r)) =
                                     (lhs.value(ctx), v)
                                 {
-                                    Some(ctx.builder.build_float_compare(OLE, l, r, "").into())
+                                    ctx.builder
+                                        .build_float_compare(OLE, l, r, "")
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -365,7 +386,10 @@ impl Type for Float {
                                 if let (Some(BasicValueEnum::FloatValue(l)), Some(r)) =
                                     (lhs.value(ctx), v)
                                 {
-                                    Some(ctx.builder.build_float_compare(OGE, l, r, "").into())
+                                    ctx.builder
+                                        .build_float_compare(OGE, l, r, "")
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -382,7 +406,10 @@ impl Type for Float {
                                 if let (Some(BasicValueEnum::FloatValue(l)), Some(r)) =
                                     (lhs.value(ctx), v)
                                 {
-                                    Some(ctx.builder.build_float_compare(OEQ, l, r, "").into())
+                                    ctx.builder
+                                        .build_float_compare(OEQ, l, r, "")
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -399,7 +426,10 @@ impl Type for Float {
                                 if let (Some(BasicValueEnum::FloatValue(l)), Some(r)) =
                                     (lhs.value(ctx), v)
                                 {
-                                    Some(ctx.builder.build_float_compare(ONE, l, r, "").into())
+                                    ctx.builder
+                                        .build_float_compare(ONE, l, r, "")
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -433,7 +463,7 @@ impl Type for Float {
                                 if let (Some(BasicValueEnum::FloatValue(l)), Some(r)) =
                                     (lhs.value(ctx), v)
                                 {
-                                    Some(ctx.builder.build_float_add(l, r, "").into())
+                                    ctx.builder.build_float_add(l, r, "").ok().map(From::from)
                                 } else {
                                     None
                                 },
@@ -450,7 +480,7 @@ impl Type for Float {
                                 if let (Some(BasicValueEnum::FloatValue(l)), Some(r)) =
                                     (lhs.value(ctx), v)
                                 {
-                                    Some(ctx.builder.build_float_sub(l, r, "").into())
+                                    ctx.builder.build_float_sub(l, r, "").ok().map(From::from)
                                 } else {
                                     None
                                 },
@@ -467,7 +497,7 @@ impl Type for Float {
                                 if let (Some(BasicValueEnum::FloatValue(l)), Some(r)) =
                                     (lhs.value(ctx), v)
                                 {
-                                    Some(ctx.builder.build_float_mul(l, r, "").into())
+                                    ctx.builder.build_float_mul(l, r, "").ok().map(From::from)
                                 } else {
                                     None
                                 },
@@ -484,7 +514,7 @@ impl Type for Float {
                                 if let (Some(BasicValueEnum::FloatValue(l)), Some(r)) =
                                     (lhs.value(ctx), v)
                                 {
-                                    Some(ctx.builder.build_float_div(l, r, "").into())
+                                    ctx.builder.build_float_div(l, r, "").ok().map(From::from)
                                 } else {
                                     None
                                 },
@@ -501,7 +531,10 @@ impl Type for Float {
                                 if let (Some(BasicValueEnum::FloatValue(l)), Some(r)) =
                                     (lhs.value(ctx), v)
                                 {
-                                    Some(ctx.builder.build_float_compare(OLT, l, r, "").into())
+                                    ctx.builder
+                                        .build_float_compare(OLT, l, r, "")
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -518,7 +551,10 @@ impl Type for Float {
                                 if let (Some(BasicValueEnum::FloatValue(l)), Some(r)) =
                                     (lhs.value(ctx), v)
                                 {
-                                    Some(ctx.builder.build_float_compare(OGT, l, r, "").into())
+                                    ctx.builder
+                                        .build_float_compare(OGT, l, r, "")
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -535,7 +571,10 @@ impl Type for Float {
                                 if let (Some(BasicValueEnum::FloatValue(l)), Some(r)) =
                                     (lhs.value(ctx), v)
                                 {
-                                    Some(ctx.builder.build_float_compare(OLE, l, r, "").into())
+                                    ctx.builder
+                                        .build_float_compare(OLE, l, r, "")
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -552,7 +591,10 @@ impl Type for Float {
                                 if let (Some(BasicValueEnum::FloatValue(l)), Some(r)) =
                                     (lhs.value(ctx), v)
                                 {
-                                    Some(ctx.builder.build_float_compare(OGE, l, r, "").into())
+                                    ctx.builder
+                                        .build_float_compare(OGE, l, r, "")
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -569,7 +611,10 @@ impl Type for Float {
                                 if let (Some(BasicValueEnum::FloatValue(l)), Some(r)) =
                                     (lhs.value(ctx), v)
                                 {
-                                    Some(ctx.builder.build_float_compare(OEQ, l, r, "").into())
+                                    ctx.builder
+                                        .build_float_compare(OEQ, l, r, "")
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -586,7 +631,10 @@ impl Type for Float {
                                 if let (Some(BasicValueEnum::FloatValue(l)), Some(r)) =
                                     (lhs.value(ctx), v)
                                 {
-                                    Some(ctx.builder.build_float_compare(ONE, l, r, "").into())
+                                    ctx.builder
+                                        .build_float_compare(ONE, l, r, "")
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -612,15 +660,14 @@ impl Type for Float {
                             Ordering::Less => {
                                 rhs.comp_val =
                                     if let Some(BasicValueEnum::FloatValue(v)) = rhs.comp_val {
-                                        Some(
-                                            ctx.builder
-                                                .build_float_cast(
-                                                    v,
-                                                    self.llvm_type(ctx).unwrap().into_float_type(),
-                                                    "",
-                                                )
-                                                .into(),
-                                        )
+                                        ctx.builder
+                                            .build_float_cast(
+                                                v,
+                                                self.llvm_type(ctx).unwrap().into_float_type(),
+                                                "",
+                                            )
+                                            .ok()
+                                            .map(From::from)
                                     } else {
                                         None
                                     };
@@ -628,15 +675,14 @@ impl Type for Float {
                             Ordering::Greater => {
                                 lhs.comp_val =
                                     if let Some(BasicValueEnum::FloatValue(v)) = lhs.comp_val {
-                                        Some(
-                                            ctx.builder
-                                                .build_float_cast(
-                                                    v,
-                                                    ty.llvm_type(ctx).unwrap().into_float_type(),
-                                                    "",
-                                                )
-                                                .into(),
-                                        )
+                                        ctx.builder
+                                            .build_float_cast(
+                                                v,
+                                                ty.llvm_type(ctx).unwrap().into_float_type(),
+                                                "",
+                                            )
+                                            .ok()
+                                            .map(From::from)
                                     } else {
                                         None
                                     };
@@ -650,7 +696,7 @@ impl Type for Float {
                                     Some(BasicValueEnum::FloatValue(r)),
                                 ) = (lhs.value(ctx), rhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_float_add(l, r, "").into())
+                                    ctx.builder.build_float_add(l, r, "").ok().map(From::from)
                                 } else {
                                     None
                                 },
@@ -669,7 +715,7 @@ impl Type for Float {
                                     Some(BasicValueEnum::FloatValue(r)),
                                 ) = (lhs.value(ctx), rhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_float_sub(l, r, "").into())
+                                    ctx.builder.build_float_sub(l, r, "").ok().map(From::from)
                                 } else {
                                     None
                                 },
@@ -688,7 +734,7 @@ impl Type for Float {
                                     Some(BasicValueEnum::FloatValue(r)),
                                 ) = (lhs.value(ctx), rhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_float_mul(l, r, "").into())
+                                    ctx.builder.build_float_mul(l, r, "").ok().map(From::from)
                                 } else {
                                     None
                                 },
@@ -707,7 +753,7 @@ impl Type for Float {
                                     Some(BasicValueEnum::FloatValue(r)),
                                 ) = (lhs.value(ctx), rhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_float_div(l, r, "").into())
+                                    ctx.builder.build_float_div(l, r, "").ok().map(From::from)
                                 } else {
                                     None
                                 },
@@ -726,7 +772,10 @@ impl Type for Float {
                                     Some(BasicValueEnum::FloatValue(r)),
                                 ) = (lhs.value(ctx), rhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_float_compare(OLT, l, r, "").into())
+                                    ctx.builder
+                                        .build_float_compare(OLT, l, r, "")
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -745,7 +794,10 @@ impl Type for Float {
                                     Some(BasicValueEnum::FloatValue(r)),
                                 ) = (lhs.value(ctx), rhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_float_compare(OGT, l, r, "").into())
+                                    ctx.builder
+                                        .build_float_compare(OGT, l, r, "")
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -764,7 +816,10 @@ impl Type for Float {
                                     Some(BasicValueEnum::FloatValue(r)),
                                 ) = (lhs.value(ctx), rhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_float_compare(OLE, l, r, "").into())
+                                    ctx.builder
+                                        .build_float_compare(OLE, l, r, "")
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -783,7 +838,10 @@ impl Type for Float {
                                     Some(BasicValueEnum::FloatValue(r)),
                                 ) = (lhs.value(ctx), rhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_float_compare(OGE, l, r, "").into())
+                                    ctx.builder
+                                        .build_float_compare(OGE, l, r, "")
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -802,7 +860,10 @@ impl Type for Float {
                                     Some(BasicValueEnum::FloatValue(r)),
                                 ) = (lhs.value(ctx), rhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_float_compare(OEQ, l, r, "").into())
+                                    ctx.builder
+                                        .build_float_compare(OEQ, l, r, "")
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -821,7 +882,10 @@ impl Type for Float {
                                     Some(BasicValueEnum::FloatValue(r)),
                                 ) = (lhs.value(ctx), rhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_float_compare(ONE, l, r, "").into())
+                                    ctx.builder
+                                        .build_float_compare(ONE, l, r, "")
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -865,13 +929,12 @@ impl Type for Float {
                     return {
                         let v = if let Some(BasicValueEnum::IntValue(v)) = lhs.value(ctx) {
                             let ft = self.llvm_type(ctx).unwrap().into_float_type();
-                            Some(
-                                if rhs.data_type.downcast::<types::Int>().unwrap().is_signed() {
-                                    ctx.builder.build_signed_int_to_float(v, ft, "")
-                                } else {
-                                    ctx.builder.build_unsigned_int_to_float(v, ft, "")
-                                },
-                            )
+                            if rhs.data_type.downcast::<types::Int>().unwrap().is_signed() {
+                                ctx.builder.build_signed_int_to_float(v, ft, "")
+                            } else {
+                                ctx.builder.build_unsigned_int_to_float(v, ft, "")
+                            }
+                            .ok()
                         } else {
                             None
                         };
@@ -880,7 +943,7 @@ impl Type for Float {
                                 if let (Some(l), Some(BasicValueEnum::FloatValue(r))) =
                                     (v, lhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_float_add(l, r, "").into())
+                                    ctx.builder.build_float_add(l, r, "").ok().map(From::from)
                                 } else {
                                     None
                                 },
@@ -897,7 +960,7 @@ impl Type for Float {
                                 if let (Some(l), Some(BasicValueEnum::FloatValue(r))) =
                                     (v, lhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_float_sub(l, r, "").into())
+                                    ctx.builder.build_float_sub(l, r, "").ok().map(From::from)
                                 } else {
                                     None
                                 },
@@ -914,7 +977,7 @@ impl Type for Float {
                                 if let (Some(l), Some(BasicValueEnum::FloatValue(r))) =
                                     (v, lhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_float_mul(l, r, "").into())
+                                    ctx.builder.build_float_mul(l, r, "").ok().map(From::from)
                                 } else {
                                     None
                                 },
@@ -931,7 +994,7 @@ impl Type for Float {
                                 if let (Some(l), Some(BasicValueEnum::FloatValue(r))) =
                                     (v, lhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_float_div(l, r, "").into())
+                                    ctx.builder.build_float_div(l, r, "").ok().map(From::from)
                                 } else {
                                     None
                                 },
@@ -948,7 +1011,10 @@ impl Type for Float {
                                 if let (Some(l), Some(BasicValueEnum::FloatValue(r))) =
                                     (v, lhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_float_compare(OLT, l, r, "").into())
+                                    ctx.builder
+                                        .build_float_compare(OLT, l, r, "")
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -965,7 +1031,10 @@ impl Type for Float {
                                 if let (Some(l), Some(BasicValueEnum::FloatValue(r))) =
                                     (v, lhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_float_compare(OGT, l, r, "").into())
+                                    ctx.builder
+                                        .build_float_compare(OGT, l, r, "")
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -982,7 +1051,10 @@ impl Type for Float {
                                 if let (Some(l), Some(BasicValueEnum::FloatValue(r))) =
                                     (v, lhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_float_compare(OLE, l, r, "").into())
+                                    ctx.builder
+                                        .build_float_compare(OLE, l, r, "")
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -999,7 +1071,10 @@ impl Type for Float {
                                 if let (Some(l), Some(BasicValueEnum::FloatValue(r))) =
                                     (v, lhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_float_compare(OGE, l, r, "").into())
+                                    ctx.builder
+                                        .build_float_compare(OGE, l, r, "")
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -1016,7 +1091,10 @@ impl Type for Float {
                                 if let (Some(l), Some(BasicValueEnum::FloatValue(r))) =
                                     (v, lhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_float_compare(OEQ, l, r, "").into())
+                                    ctx.builder
+                                        .build_float_compare(OEQ, l, r, "")
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -1033,7 +1111,10 @@ impl Type for Float {
                                 if let (Some(l), Some(BasicValueEnum::FloatValue(r))) =
                                     (v, lhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_float_compare(ONE, l, r, "").into())
+                                    ctx.builder
+                                        .build_float_compare(ONE, l, r, "")
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -1067,7 +1148,7 @@ impl Type for Float {
                                 if let (Some(l), Some(BasicValueEnum::FloatValue(r))) =
                                     (v, lhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_float_add(l, r, "").into())
+                                    ctx.builder.build_float_add(l, r, "").ok().map(From::from)
                                 } else {
                                     None
                                 },
@@ -1084,7 +1165,7 @@ impl Type for Float {
                                 if let (Some(l), Some(BasicValueEnum::FloatValue(r))) =
                                     (v, lhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_float_sub(l, r, "").into())
+                                    ctx.builder.build_float_sub(l, r, "").ok().map(From::from)
                                 } else {
                                     None
                                 },
@@ -1101,7 +1182,7 @@ impl Type for Float {
                                 if let (Some(l), Some(BasicValueEnum::FloatValue(r))) =
                                     (v, lhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_float_mul(l, r, "").into())
+                                    ctx.builder.build_float_mul(l, r, "").ok().map(From::from)
                                 } else {
                                     None
                                 },
@@ -1118,7 +1199,7 @@ impl Type for Float {
                                 if let (Some(l), Some(BasicValueEnum::FloatValue(r))) =
                                     (v, lhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_float_div(l, r, "").into())
+                                    ctx.builder.build_float_div(l, r, "").ok().map(From::from)
                                 } else {
                                     None
                                 },
@@ -1154,8 +1235,15 @@ impl Type for Float {
             "++" => Ok(Value::new(
                 if let Some(BasicValueEnum::PointerValue(pv)) = val.comp_val {
                     let ft = self.llvm_type(ctx).unwrap().into_float_type();
-                    let v1 = ctx.builder.build_load(ft, pv, "").into_float_value();
-                    let v2 = ctx.builder.build_float_add(v1, ft.const_float(1.0), "");
+                    let v1 = ctx
+                        .builder
+                        .build_load(ft, pv, "")
+                        .unwrap()
+                        .into_float_value();
+                    let v2 = ctx
+                        .builder
+                        .build_float_add(v1, ft.const_float(1.0), "")
+                        .unwrap();
                     ctx.builder.build_store(pv, v2);
                     val.comp_val
                 } else {
@@ -1167,8 +1255,15 @@ impl Type for Float {
             "--" => Ok(Value::new(
                 if let Some(BasicValueEnum::PointerValue(pv)) = val.comp_val {
                     let ft = self.llvm_type(ctx).unwrap().into_float_type();
-                    let v1 = ctx.builder.build_load(ft, pv, "").into_float_value();
-                    let v2 = ctx.builder.build_float_sub(v1, ft.const_float(1.0), "");
+                    let v1 = ctx
+                        .builder
+                        .build_load(ft, pv, "")
+                        .unwrap()
+                        .into_float_value();
+                    let v2 = ctx
+                        .builder
+                        .build_float_sub(v1, ft.const_float(1.0), "")
+                        .unwrap();
                     ctx.builder.build_store(pv, v2);
                     val.comp_val
                 } else {
@@ -1212,23 +1307,39 @@ impl Type for Float {
                         let rv = lty.const_float(*rv as _);
                         match op.0 {
                             "+=" => {
-                                let v1 = ctx.builder.build_load(lty, lv, "").into_float_value();
-                                let v2 = ctx.builder.build_float_add(v1, rv, "");
+                                let v1 = ctx
+                                    .builder
+                                    .build_load(lty, lv, "")
+                                    .unwrap()
+                                    .into_float_value();
+                                let v2 = ctx.builder.build_float_add(v1, rv, "").unwrap();
                                 ctx.builder.build_store(lv, v2);
                             }
                             "-=" => {
-                                let v1 = ctx.builder.build_load(lty, lv, "").into_float_value();
-                                let v2 = ctx.builder.build_float_sub(v1, rv, "");
+                                let v1 = ctx
+                                    .builder
+                                    .build_load(lty, lv, "")
+                                    .unwrap()
+                                    .into_float_value();
+                                let v2 = ctx.builder.build_float_sub(v1, rv, "").unwrap();
                                 ctx.builder.build_store(lv, v2);
                             }
                             "*=" => {
-                                let v1 = ctx.builder.build_load(lty, lv, "").into_float_value();
-                                let v2 = ctx.builder.build_float_mul(v1, rv, "");
+                                let v1 = ctx
+                                    .builder
+                                    .build_load(lty, lv, "")
+                                    .unwrap()
+                                    .into_float_value();
+                                let v2 = ctx.builder.build_float_mul(v1, rv, "").unwrap();
                                 ctx.builder.build_store(lv, v2);
                             }
                             "/=" => {
-                                let v1 = ctx.builder.build_load(lty, lv, "").into_float_value();
-                                let v2 = ctx.builder.build_float_div(v1, rv, "");
+                                let v1 = ctx
+                                    .builder
+                                    .build_load(lty, lv, "")
+                                    .unwrap()
+                                    .into_float_value();
+                                let v2 = ctx.builder.build_float_div(v1, rv, "").unwrap();
                                 ctx.builder.build_store(lv, v2);
                             }
                             _ => return Err(invalid_binop(&lhs, &rhs, op.0, op.1)),
@@ -1259,26 +1370,43 @@ impl Type for Float {
                             ctx.builder.build_signed_int_to_float(rv, lty, "")
                         } else {
                             ctx.builder.build_unsigned_int_to_float(rv, lty, "")
-                        };
+                        }
+                        .unwrap();
                         match op.0 {
                             "+=" => {
-                                let v1 = ctx.builder.build_load(lty, lv, "").into_float_value();
-                                let v2 = ctx.builder.build_float_add(v1, rv, "");
+                                let v1 = ctx
+                                    .builder
+                                    .build_load(lty, lv, "")
+                                    .unwrap()
+                                    .into_float_value();
+                                let v2 = ctx.builder.build_float_add(v1, rv, "").unwrap();
                                 ctx.builder.build_store(lv, v2);
                             }
                             "-=" => {
-                                let v1 = ctx.builder.build_load(lty, lv, "").into_float_value();
-                                let v2 = ctx.builder.build_float_sub(v1, rv, "");
+                                let v1 = ctx
+                                    .builder
+                                    .build_load(lty, lv, "")
+                                    .unwrap()
+                                    .into_float_value();
+                                let v2 = ctx.builder.build_float_sub(v1, rv, "").unwrap();
                                 ctx.builder.build_store(lv, v2);
                             }
                             "*=" => {
-                                let v1 = ctx.builder.build_load(lty, lv, "").into_float_value();
-                                let v2 = ctx.builder.build_float_mul(v1, rv, "");
+                                let v1 = ctx
+                                    .builder
+                                    .build_load(lty, lv, "")
+                                    .unwrap()
+                                    .into_float_value();
+                                let v2 = ctx.builder.build_float_mul(v1, rv, "").unwrap();
                                 ctx.builder.build_store(lv, v2);
                             }
                             "/=" => {
-                                let v1 = ctx.builder.build_load(lty, lv, "").into_float_value();
-                                let v2 = ctx.builder.build_float_div(v1, rv, "");
+                                let v1 = ctx
+                                    .builder
+                                    .build_load(lty, lv, "")
+                                    .unwrap()
+                                    .into_float_value();
+                                let v2 = ctx.builder.build_float_div(v1, rv, "").unwrap();
                                 ctx.builder.build_store(lv, v2);
                             }
                             _ => return Err(invalid_binop(&lhs, &rhs, op.0, op.1)),
@@ -1304,26 +1432,42 @@ impl Type for Float {
                         Some(BasicValueEnum::FloatValue(rv)),
                     ) = (lhs.value(ctx), rhs.value(ctx))
                     {
-                        let rv = ctx.builder.build_float_cast(rv, lty, "");
+                        let rv = ctx.builder.build_float_cast(rv, lty, "").unwrap();
                         match op.0 {
                             "+=" => {
-                                let v1 = ctx.builder.build_load(lty, lv, "").into_float_value();
-                                let v2 = ctx.builder.build_float_add(v1, rv, "");
+                                let v1 = ctx
+                                    .builder
+                                    .build_load(lty, lv, "")
+                                    .unwrap()
+                                    .into_float_value();
+                                let v2 = ctx.builder.build_float_add(v1, rv, "").unwrap();
                                 ctx.builder.build_store(lv, v2);
                             }
                             "-=" => {
-                                let v1 = ctx.builder.build_load(lty, lv, "").into_float_value();
-                                let v2 = ctx.builder.build_float_sub(v1, rv, "");
+                                let v1 = ctx
+                                    .builder
+                                    .build_load(lty, lv, "")
+                                    .unwrap()
+                                    .into_float_value();
+                                let v2 = ctx.builder.build_float_sub(v1, rv, "").unwrap();
                                 ctx.builder.build_store(lv, v2);
                             }
                             "*=" => {
-                                let v1 = ctx.builder.build_load(lty, lv, "").into_float_value();
-                                let v2 = ctx.builder.build_float_mul(v1, rv, "");
+                                let v1 = ctx
+                                    .builder
+                                    .build_load(lty, lv, "")
+                                    .unwrap()
+                                    .into_float_value();
+                                let v2 = ctx.builder.build_float_mul(v1, rv, "").unwrap();
                                 ctx.builder.build_store(lv, v2);
                             }
                             "/=" => {
-                                let v1 = ctx.builder.build_load(lty, lv, "").into_float_value();
-                                let v2 = ctx.builder.build_float_div(v1, rv, "");
+                                let v1 = ctx
+                                    .builder
+                                    .build_load(lty, lv, "")
+                                    .unwrap()
+                                    .into_float_value();
+                                let v2 = ctx.builder.build_float_div(v1, rv, "").unwrap();
                                 ctx.builder.build_store(lv, v2);
                             }
                             _ => return Err(invalid_binop(&lhs, &rhs, op.0, op.1)),

--- a/cobalt-ast/src/types/func.rs
+++ b/cobalt-ast/src/types/func.rs
@@ -208,7 +208,10 @@ impl Type for Function {
         use inkwell::values::BasicValue;
         Ok(Value::new(
             val.and_then(|v| {
-                let call = ctx.builder.build_indirect_call(fty?, v, &args_v, "");
+                let call = ctx
+                    .builder
+                    .build_indirect_call(fty?, v, &args_v, "")
+                    .unwrap();
                 let inst = call
                     .try_as_basic_value()
                     .right_or_else(|v| v.as_instruction_value().unwrap());
@@ -316,7 +319,7 @@ impl Type for BoundMethod {
     fn ins_dtor<'src, 'ctx>(&'static self, val: &Value<'src, 'ctx>, ctx: &CompCtx<'src, 'ctx>) {
         if let Some(BasicValueEnum::StructValue(sv)) = val.comp_val {
             Value::new(
-                ctx.builder.build_extract_value(sv, 0, ""),
+                ctx.builder.build_extract_value(sv, 0, "").ok(),
                 None,
                 self.self_ty(),
             )
@@ -335,8 +338,8 @@ impl Type for BoundMethod {
     ) -> Result<Value<'src, 'ctx>, CobaltError<'src>> {
         let (comp_val, fv) = match val.comp_val {
             Some(BasicValueEnum::StructValue(sv)) => (
-                ctx.builder.build_extract_value(sv, 0, ""),
-                ctx.builder.build_extract_value(sv, 1, ""),
+                ctx.builder.build_extract_value(sv, 0, "").ok(),
+                ctx.builder.build_extract_value(sv, 1, "").ok(),
             ),
             Some(BasicValueEnum::PointerValue(pv)) => (None, Some(pv.into())),
             _ => (None, None),

--- a/cobalt-ast/src/types/int.rs
+++ b/cobalt-ast/src/types/int.rs
@@ -66,7 +66,7 @@ impl Type for Int {
             "+" => Ok(val),
             "-" => Ok(Value {
                 comp_val: if let Some(BasicValueEnum::IntValue(v)) = val.value(ctx) {
-                    Some(ctx.builder.build_int_neg(v, "").into())
+                    ctx.builder.build_int_neg(v, "").ok().map(From::from)
                 } else {
                     None
                 },
@@ -79,7 +79,7 @@ impl Type for Int {
             }),
             "~" => Ok(Value {
                 comp_val: if let Some(BasicValueEnum::IntValue(v)) = val.value(ctx) {
-                    Some(ctx.builder.build_not(v, "").into())
+                    ctx.builder.build_not(v, "").ok().map(From::from)
                 } else {
                     None
                 },
@@ -92,11 +92,10 @@ impl Type for Int {
             }),
             "!" => Ok(Value::new(
                 if let Some(BasicValueEnum::IntValue(v)) = val.value(ctx) {
-                    Some(
-                        ctx.builder
-                            .build_int_compare(EQ, v, v.get_type().const_zero(), "")
-                            .into(),
-                    )
+                    ctx.builder
+                        .build_int_compare(EQ, v, v.get_type().const_zero(), "")
+                        .ok()
+                        .map(From::from)
                 } else {
                     None
                 },
@@ -137,9 +136,15 @@ impl Type for Int {
                     } else if let Some(BasicValueEnum::IntValue(v)) = val.comp_val {
                         let ty = target.0.llvm_type(ctx).unwrap().into_int_type();
                         if self.is_signed() {
-                            Some(ctx.builder.build_int_s_extend(v, ty, "").into())
+                            ctx.builder
+                                .build_int_s_extend(v, ty, "")
+                                .ok()
+                                .map(From::from)
                         } else {
-                            Some(ctx.builder.build_int_z_extend(v, ty, "").into())
+                            ctx.builder
+                                .build_int_z_extend(v, ty, "")
+                                .ok()
+                                .map(From::from)
                         }
                     } else {
                         None
@@ -164,9 +169,15 @@ impl Type for Int {
                 if let Some(BasicValueEnum::IntValue(v)) = val.comp_val {
                     let ty = target.0.llvm_type(ctx).unwrap().into_float_type();
                     if self.is_signed() {
-                        Some(ctx.builder.build_signed_int_to_float(v, ty, "").into())
+                        ctx.builder
+                            .build_signed_int_to_float(v, ty, "")
+                            .ok()
+                            .map(From::from)
                     } else {
-                        Some(ctx.builder.build_unsigned_int_to_float(v, ty, "").into())
+                        ctx.builder
+                            .build_unsigned_int_to_float(v, ty, "")
+                            .ok()
+                            .map(From::from)
                     }
                 } else {
                     None
@@ -196,12 +207,22 @@ impl Type for Int {
                     match ty.bits().cmp(&self.bits()) {
                         Ordering::Greater => {
                             if self.is_signed() {
-                                Some(ctx.builder.build_int_s_extend(v, it, "").into())
+                                ctx.builder
+                                    .build_int_s_extend(v, it, "")
+                                    .ok()
+                                    .map(From::from)
                             } else {
-                                Some(ctx.builder.build_int_z_extend(v, it, "").into())
+                                ctx.builder
+                                    .build_int_z_extend(v, it, "")
+                                    .ok()
+                                    .map(From::from)
                             }
                         }
-                        Ordering::Less => Some(ctx.builder.build_int_truncate(v, it, "").into()),
+                        Ordering::Less => ctx
+                            .builder
+                            .build_int_truncate(v, it, "")
+                            .ok()
+                            .map(From::from),
                         Ordering::Equal => Some(v.into()),
                     }
                 } else {
@@ -218,7 +239,7 @@ impl Type for Int {
             Ok(Value::new(
                 if let Some(BasicValueEnum::IntValue(v)) = val.comp_val {
                     let ty = target.0.llvm_type(ctx).unwrap().into_pointer_type();
-                    Some(ctx.builder.build_int_to_ptr(v, ty, "").into())
+                    ctx.builder.build_int_to_ptr(v, ty, "").ok().map(From::from)
                 } else {
                     None
                 },
@@ -284,10 +305,8 @@ impl Type for Int {
                         let ty = rhs.data_type.downcast::<types::Int>().unwrap();
                         let res = match self.bits().cmp(&ty.bits()) {
                             Ordering::Less => {
-                                lhs.comp_val = if let Some(BasicValueEnum::IntValue(v)) =
-                                    lhs.comp_val
-                                {
-                                    Some(
+                                lhs.comp_val =
+                                    if let Some(BasicValueEnum::IntValue(v)) = lhs.comp_val {
                                         if self.is_signed() {
                                             ctx.builder.build_int_s_extend(
                                                 v,
@@ -301,29 +320,27 @@ impl Type for Int {
                                                 "",
                                             )
                                         }
-                                        .into(),
-                                    )
-                                } else {
-                                    None
-                                };
+                                        .ok()
+                                        .map(From::from)
+                                    } else {
+                                        None
+                                    };
                                 ty
                             }
                             Ordering::Greater => {
-                                rhs.comp_val = if let Some(BasicValueEnum::IntValue(v)) =
-                                    rhs.comp_val
-                                {
-                                    Some(
+                                rhs.comp_val =
+                                    if let Some(BasicValueEnum::IntValue(v)) = rhs.comp_val {
                                         ctx.builder
                                             .build_int_z_extend(
                                                 v,
                                                 ctx.context.custom_width_int_type(self.bits() as _),
                                                 "",
                                             )
-                                            .into(),
-                                    )
-                                } else {
-                                    None
-                                };
+                                            .ok()
+                                            .map(From::from)
+                                    } else {
+                                        None
+                                    };
                                 self
                             }
                             Ordering::Equal => {
@@ -337,7 +354,7 @@ impl Type for Int {
                                     Some(BasicValueEnum::IntValue(r)),
                                 ) = (lhs.value(ctx), rhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_int_add(l, r, "").into())
+                                    ctx.builder.build_int_add(l, r, "").ok().map(From::from)
                                 } else {
                                     None
                                 },
@@ -356,7 +373,7 @@ impl Type for Int {
                                     Some(BasicValueEnum::IntValue(r)),
                                 ) = (lhs.value(ctx), rhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_int_sub(l, r, "").into())
+                                    ctx.builder.build_int_sub(l, r, "").ok().map(From::from)
                                 } else {
                                     None
                                 },
@@ -375,7 +392,7 @@ impl Type for Int {
                                     Some(BasicValueEnum::IntValue(r)),
                                 ) = (lhs.value(ctx), rhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_int_mul(l, r, "").into())
+                                    ctx.builder.build_int_mul(l, r, "").ok().map(From::from)
                                 } else {
                                     None
                                 },
@@ -394,14 +411,13 @@ impl Type for Int {
                                     Some(BasicValueEnum::IntValue(r)),
                                 ) = (lhs.value(ctx), rhs.value(ctx))
                                 {
-                                    Some(
-                                        if self.is_signed() || ty.is_signed() {
-                                            ctx.builder.build_int_signed_div(l, r, "")
-                                        } else {
-                                            ctx.builder.build_int_unsigned_div(l, r, "")
-                                        }
-                                        .into(),
-                                    )
+                                    if self.is_signed() || ty.is_signed() {
+                                        ctx.builder.build_int_signed_div(l, r, "")
+                                    } else {
+                                        ctx.builder.build_int_unsigned_div(l, r, "")
+                                    }
+                                    .ok()
+                                    .map(From::from)
                                 } else {
                                     None
                                 },
@@ -420,14 +436,13 @@ impl Type for Int {
                                     Some(BasicValueEnum::IntValue(r)),
                                 ) = (lhs.value(ctx), rhs.value(ctx))
                                 {
-                                    Some(
-                                        if self.is_signed() || ty.is_signed() {
-                                            ctx.builder.build_int_signed_div(l, r, "")
-                                        } else {
-                                            ctx.builder.build_int_unsigned_div(l, r, "")
-                                        }
-                                        .into(),
-                                    )
+                                    if self.is_signed() || ty.is_signed() {
+                                        ctx.builder.build_int_signed_div(l, r, "")
+                                    } else {
+                                        ctx.builder.build_int_unsigned_div(l, r, "")
+                                    }
+                                    .ok()
+                                    .map(From::from)
                                 } else {
                                     None
                                 },
@@ -446,7 +461,7 @@ impl Type for Int {
                                     Some(BasicValueEnum::IntValue(r)),
                                 ) = (lhs.value(ctx), rhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_and(l, r, "").into())
+                                    ctx.builder.build_and(l, r, "").ok().map(From::from)
                                 } else {
                                     None
                                 },
@@ -465,7 +480,7 @@ impl Type for Int {
                                     Some(BasicValueEnum::IntValue(r)),
                                 ) = (lhs.value(ctx), rhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_or(l, r, "").into())
+                                    ctx.builder.build_or(l, r, "").ok().map(From::from)
                                 } else {
                                     None
                                 },
@@ -484,7 +499,7 @@ impl Type for Int {
                                     Some(BasicValueEnum::IntValue(r)),
                                 ) = (lhs.value(ctx), rhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_xor(l, r, "").into())
+                                    ctx.builder.build_xor(l, r, "").ok().map(From::from)
                                 } else {
                                     None
                                 },
@@ -503,7 +518,7 @@ impl Type for Int {
                                     Some(BasicValueEnum::IntValue(r)),
                                 ) = (lhs.value(ctx), rhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_left_shift(l, r, "").into())
+                                    ctx.builder.build_left_shift(l, r, "").ok().map(From::from)
                                 } else {
                                     None
                                 },
@@ -522,11 +537,10 @@ impl Type for Int {
                                     Some(BasicValueEnum::IntValue(r)),
                                 ) = (lhs.value(ctx), rhs.value(ctx))
                                 {
-                                    Some(
-                                        ctx.builder
-                                            .build_right_shift(l, r, res.is_signed(), "")
-                                            .into(),
-                                    )
+                                    ctx.builder
+                                        .build_right_shift(l, r, res.is_signed(), "")
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -545,16 +559,15 @@ impl Type for Int {
                                     Some(BasicValueEnum::IntValue(r)),
                                 ) = (lhs.value(ctx), rhs.value(ctx))
                                 {
-                                    Some(
-                                        ctx.builder
-                                            .build_int_compare(
-                                                if res.is_signed() { SLT } else { ULT },
-                                                l,
-                                                r,
-                                                "",
-                                            )
-                                            .into(),
-                                    )
+                                    ctx.builder
+                                        .build_int_compare(
+                                            if res.is_signed() { SLT } else { ULT },
+                                            l,
+                                            r,
+                                            "",
+                                        )
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -573,16 +586,15 @@ impl Type for Int {
                                     Some(BasicValueEnum::IntValue(r)),
                                 ) = (lhs.value(ctx), rhs.value(ctx))
                                 {
-                                    Some(
-                                        ctx.builder
-                                            .build_int_compare(
-                                                if res.is_signed() { SGT } else { UGT },
-                                                l,
-                                                r,
-                                                "",
-                                            )
-                                            .into(),
-                                    )
+                                    ctx.builder
+                                        .build_int_compare(
+                                            if res.is_signed() { SGT } else { UGT },
+                                            l,
+                                            r,
+                                            "",
+                                        )
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -601,16 +613,15 @@ impl Type for Int {
                                     Some(BasicValueEnum::IntValue(r)),
                                 ) = (lhs.value(ctx), rhs.value(ctx))
                                 {
-                                    Some(
-                                        ctx.builder
-                                            .build_int_compare(
-                                                if res.is_signed() { SLE } else { ULE },
-                                                l,
-                                                r,
-                                                "",
-                                            )
-                                            .into(),
-                                    )
+                                    ctx.builder
+                                        .build_int_compare(
+                                            if res.is_signed() { SLE } else { ULE },
+                                            l,
+                                            r,
+                                            "",
+                                        )
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -629,16 +640,15 @@ impl Type for Int {
                                     Some(BasicValueEnum::IntValue(r)),
                                 ) = (lhs.value(ctx), rhs.value(ctx))
                                 {
-                                    Some(
-                                        ctx.builder
-                                            .build_int_compare(
-                                                if res.is_signed() { SGE } else { UGE },
-                                                l,
-                                                r,
-                                                "",
-                                            )
-                                            .into(),
-                                    )
+                                    ctx.builder
+                                        .build_int_compare(
+                                            if res.is_signed() { SGE } else { UGE },
+                                            l,
+                                            r,
+                                            "",
+                                        )
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -657,7 +667,10 @@ impl Type for Int {
                                     Some(BasicValueEnum::IntValue(r)),
                                 ) = (lhs.value(ctx), rhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_int_compare(EQ, l, r, "").into())
+                                    ctx.builder
+                                        .build_int_compare(EQ, l, r, "")
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -676,7 +689,10 @@ impl Type for Int {
                                     Some(BasicValueEnum::IntValue(r)),
                                 ) = (lhs.value(ctx), rhs.value(ctx))
                                 {
-                                    Some(ctx.builder.build_int_compare(NE, l, r, "").into())
+                                    ctx.builder
+                                        .build_int_compare(NE, l, r, "")
+                                        .ok()
+                                        .map(From::from)
                                 } else {
                                     None
                                 },
@@ -699,17 +715,16 @@ impl Type for Int {
                             if let (Some(BasicValueEnum::IntValue(l)), Some(InterData::Int(r))) =
                                 (lhs.value(ctx), &rhs.inter_val)
                             {
-                                Some(
-                                    ctx.builder
-                                        .build_int_add(
-                                            l,
-                                            ctx.context
-                                                .custom_width_int_type(self.bits() as _)
-                                                .const_int(*r as _, self.is_signed()),
-                                            "",
-                                        )
-                                        .into(),
-                                )
+                                ctx.builder
+                                    .build_int_add(
+                                        l,
+                                        ctx.context
+                                            .custom_width_int_type(self.bits() as _)
+                                            .const_int(*r as _, self.is_signed()),
+                                        "",
+                                    )
+                                    .ok()
+                                    .map(From::from)
                             } else {
                                 None
                             },
@@ -726,17 +741,16 @@ impl Type for Int {
                             if let (Some(BasicValueEnum::IntValue(l)), Some(InterData::Int(r))) =
                                 (lhs.value(ctx), &rhs.inter_val)
                             {
-                                Some(
-                                    ctx.builder
-                                        .build_int_sub(
-                                            l,
-                                            ctx.context
-                                                .custom_width_int_type(self.bits() as _)
-                                                .const_int(*r as _, self.is_signed()),
-                                            "",
-                                        )
-                                        .into(),
-                                )
+                                ctx.builder
+                                    .build_int_sub(
+                                        l,
+                                        ctx.context
+                                            .custom_width_int_type(self.bits() as _)
+                                            .const_int(*r as _, self.is_signed()),
+                                        "",
+                                    )
+                                    .ok()
+                                    .map(From::from)
                             } else {
                                 None
                             },
@@ -753,17 +767,16 @@ impl Type for Int {
                             if let (Some(BasicValueEnum::IntValue(l)), Some(InterData::Int(r))) =
                                 (lhs.value(ctx), &rhs.inter_val)
                             {
-                                Some(
-                                    ctx.builder
-                                        .build_int_mul(
-                                            l,
-                                            ctx.context
-                                                .custom_width_int_type(self.bits() as _)
-                                                .const_int(*r as _, self.is_signed()),
-                                            "",
-                                        )
-                                        .into(),
-                                )
+                                ctx.builder
+                                    .build_int_mul(
+                                        l,
+                                        ctx.context
+                                            .custom_width_int_type(self.bits() as _)
+                                            .const_int(*r as _, self.is_signed()),
+                                        "",
+                                    )
+                                    .ok()
+                                    .map(From::from)
                             } else {
                                 None
                             },
@@ -784,14 +797,13 @@ impl Type for Int {
                                     .context
                                     .custom_width_int_type(self.bits() as _)
                                     .const_int(*r as _, self.is_signed());
-                                Some(
-                                    if self.is_signed() {
-                                        ctx.builder.build_int_signed_div(l, r, "")
-                                    } else {
-                                        ctx.builder.build_int_unsigned_div(l, r, "")
-                                    }
-                                    .into(),
-                                )
+                                if self.is_signed() {
+                                    ctx.builder.build_int_signed_div(l, r, "")
+                                } else {
+                                    ctx.builder.build_int_unsigned_div(l, r, "")
+                                }
+                                .ok()
+                                .map(From::from)
                             } else {
                                 None
                             },
@@ -812,14 +824,13 @@ impl Type for Int {
                                     .context
                                     .custom_width_int_type(self.bits() as _)
                                     .const_int(*r as _, self.is_signed());
-                                Some(
-                                    if self.is_signed() {
-                                        ctx.builder.build_int_signed_rem(l, r, "")
-                                    } else {
-                                        ctx.builder.build_int_unsigned_rem(l, r, "")
-                                    }
-                                    .into(),
-                                )
+                                if self.is_signed() {
+                                    ctx.builder.build_int_signed_rem(l, r, "")
+                                } else {
+                                    ctx.builder.build_int_unsigned_rem(l, r, "")
+                                }
+                                .ok()
+                                .map(From::from)
                             } else {
                                 None
                             },
@@ -836,17 +847,16 @@ impl Type for Int {
                             if let (Some(BasicValueEnum::IntValue(l)), Some(InterData::Int(r))) =
                                 (lhs.value(ctx), &rhs.inter_val)
                             {
-                                Some(
-                                    ctx.builder
-                                        .build_and(
-                                            l,
-                                            ctx.context
-                                                .custom_width_int_type(self.bits() as _)
-                                                .const_int(*r as _, self.is_signed()),
-                                            "",
-                                        )
-                                        .into(),
-                                )
+                                ctx.builder
+                                    .build_and(
+                                        l,
+                                        ctx.context
+                                            .custom_width_int_type(self.bits() as _)
+                                            .const_int(*r as _, self.is_signed()),
+                                        "",
+                                    )
+                                    .ok()
+                                    .map(From::from)
                             } else {
                                 None
                             },
@@ -863,17 +873,16 @@ impl Type for Int {
                             if let (Some(BasicValueEnum::IntValue(l)), Some(InterData::Int(r))) =
                                 (lhs.value(ctx), &rhs.inter_val)
                             {
-                                Some(
-                                    ctx.builder
-                                        .build_or(
-                                            l,
-                                            ctx.context
-                                                .custom_width_int_type(self.bits() as _)
-                                                .const_int(*r as _, self.is_signed()),
-                                            "",
-                                        )
-                                        .into(),
-                                )
+                                ctx.builder
+                                    .build_or(
+                                        l,
+                                        ctx.context
+                                            .custom_width_int_type(self.bits() as _)
+                                            .const_int(*r as _, self.is_signed()),
+                                        "",
+                                    )
+                                    .ok()
+                                    .map(From::from)
                             } else {
                                 None
                             },
@@ -890,17 +899,16 @@ impl Type for Int {
                             if let (Some(BasicValueEnum::IntValue(l)), Some(InterData::Int(r))) =
                                 (lhs.value(ctx), &rhs.inter_val)
                             {
-                                Some(
-                                    ctx.builder
-                                        .build_xor(
-                                            l,
-                                            ctx.context
-                                                .custom_width_int_type(self.bits() as _)
-                                                .const_int(*r as _, self.is_signed()),
-                                            "",
-                                        )
-                                        .into(),
-                                )
+                                ctx.builder
+                                    .build_xor(
+                                        l,
+                                        ctx.context
+                                            .custom_width_int_type(self.bits() as _)
+                                            .const_int(*r as _, self.is_signed()),
+                                        "",
+                                    )
+                                    .ok()
+                                    .map(From::from)
                             } else {
                                 None
                             },
@@ -917,17 +925,16 @@ impl Type for Int {
                             if let (Some(BasicValueEnum::IntValue(l)), Some(InterData::Int(r))) =
                                 (lhs.value(ctx), &rhs.inter_val)
                             {
-                                Some(
-                                    ctx.builder
-                                        .build_left_shift(
-                                            l,
-                                            ctx.context
-                                                .custom_width_int_type(self.bits() as _)
-                                                .const_int(*r as _, self.is_signed()),
-                                            "",
-                                        )
-                                        .into(),
-                                )
+                                ctx.builder
+                                    .build_left_shift(
+                                        l,
+                                        ctx.context
+                                            .custom_width_int_type(self.bits() as _)
+                                            .const_int(*r as _, self.is_signed()),
+                                        "",
+                                    )
+                                    .ok()
+                                    .map(From::from)
                             } else {
                                 None
                             },
@@ -944,18 +951,17 @@ impl Type for Int {
                             if let (Some(BasicValueEnum::IntValue(l)), Some(InterData::Int(r))) =
                                 (lhs.value(ctx), &rhs.inter_val)
                             {
-                                Some(
-                                    ctx.builder
-                                        .build_right_shift(
-                                            l,
-                                            ctx.context
-                                                .custom_width_int_type(self.bits() as _)
-                                                .const_int(*r as _, self.is_signed()),
-                                            self.is_signed(),
-                                            "",
-                                        )
-                                        .into(),
-                                )
+                                ctx.builder
+                                    .build_right_shift(
+                                        l,
+                                        ctx.context
+                                            .custom_width_int_type(self.bits() as _)
+                                            .const_int(*r as _, self.is_signed()),
+                                        self.is_signed(),
+                                        "",
+                                    )
+                                    .ok()
+                                    .map(From::from)
                             } else {
                                 None
                             },
@@ -972,18 +978,17 @@ impl Type for Int {
                             if let (Some(BasicValueEnum::IntValue(l)), Some(InterData::Int(r))) =
                                 (lhs.value(ctx), &rhs.inter_val)
                             {
-                                Some(
-                                    ctx.builder
-                                        .build_int_compare(
-                                            if self.is_signed() { SLT } else { ULT },
-                                            l,
-                                            ctx.context
-                                                .custom_width_int_type(self.bits() as _)
-                                                .const_int(*r as _, self.is_signed()),
-                                            "",
-                                        )
-                                        .into(),
-                                )
+                                ctx.builder
+                                    .build_int_compare(
+                                        if self.is_signed() { SLT } else { ULT },
+                                        l,
+                                        ctx.context
+                                            .custom_width_int_type(self.bits() as _)
+                                            .const_int(*r as _, self.is_signed()),
+                                        "",
+                                    )
+                                    .ok()
+                                    .map(From::from)
                             } else {
                                 None
                             },
@@ -1000,18 +1005,17 @@ impl Type for Int {
                             if let (Some(BasicValueEnum::IntValue(l)), Some(InterData::Int(r))) =
                                 (lhs.value(ctx), &rhs.inter_val)
                             {
-                                Some(
-                                    ctx.builder
-                                        .build_int_compare(
-                                            if self.is_signed() { SGT } else { UGT },
-                                            l,
-                                            ctx.context
-                                                .custom_width_int_type(self.bits() as _)
-                                                .const_int(*r as _, self.is_signed()),
-                                            "",
-                                        )
-                                        .into(),
-                                )
+                                ctx.builder
+                                    .build_int_compare(
+                                        if self.is_signed() { SGT } else { UGT },
+                                        l,
+                                        ctx.context
+                                            .custom_width_int_type(self.bits() as _)
+                                            .const_int(*r as _, self.is_signed()),
+                                        "",
+                                    )
+                                    .ok()
+                                    .map(From::from)
                             } else {
                                 None
                             },
@@ -1028,18 +1032,17 @@ impl Type for Int {
                             if let (Some(BasicValueEnum::IntValue(l)), Some(InterData::Int(r))) =
                                 (lhs.value(ctx), &rhs.inter_val)
                             {
-                                Some(
-                                    ctx.builder
-                                        .build_int_compare(
-                                            if self.is_signed() { SLE } else { ULE },
-                                            l,
-                                            ctx.context
-                                                .custom_width_int_type(self.bits() as _)
-                                                .const_int(*r as _, self.is_signed()),
-                                            "",
-                                        )
-                                        .into(),
-                                )
+                                ctx.builder
+                                    .build_int_compare(
+                                        if self.is_signed() { SLE } else { ULE },
+                                        l,
+                                        ctx.context
+                                            .custom_width_int_type(self.bits() as _)
+                                            .const_int(*r as _, self.is_signed()),
+                                        "",
+                                    )
+                                    .ok()
+                                    .map(From::from)
                             } else {
                                 None
                             },
@@ -1056,18 +1059,17 @@ impl Type for Int {
                             if let (Some(BasicValueEnum::IntValue(l)), Some(InterData::Int(r))) =
                                 (lhs.value(ctx), &rhs.inter_val)
                             {
-                                Some(
-                                    ctx.builder
-                                        .build_int_compare(
-                                            if self.is_signed() { SGE } else { UGE },
-                                            l,
-                                            ctx.context
-                                                .custom_width_int_type(self.bits() as _)
-                                                .const_int(*r as _, self.is_signed()),
-                                            "",
-                                        )
-                                        .into(),
-                                )
+                                ctx.builder
+                                    .build_int_compare(
+                                        if self.is_signed() { SGE } else { UGE },
+                                        l,
+                                        ctx.context
+                                            .custom_width_int_type(self.bits() as _)
+                                            .const_int(*r as _, self.is_signed()),
+                                        "",
+                                    )
+                                    .ok()
+                                    .map(From::from)
                             } else {
                                 None
                             },
@@ -1084,18 +1086,17 @@ impl Type for Int {
                             if let (Some(BasicValueEnum::IntValue(l)), Some(InterData::Int(r))) =
                                 (lhs.value(ctx), &rhs.inter_val)
                             {
-                                Some(
-                                    ctx.builder
-                                        .build_int_compare(
-                                            EQ,
-                                            l,
-                                            ctx.context
-                                                .custom_width_int_type(self.bits() as _)
-                                                .const_int(*r as _, self.is_signed()),
-                                            "",
-                                        )
-                                        .into(),
-                                )
+                                ctx.builder
+                                    .build_int_compare(
+                                        EQ,
+                                        l,
+                                        ctx.context
+                                            .custom_width_int_type(self.bits() as _)
+                                            .const_int(*r as _, self.is_signed()),
+                                        "",
+                                    )
+                                    .ok()
+                                    .map(From::from)
                             } else {
                                 None
                             },
@@ -1112,18 +1113,17 @@ impl Type for Int {
                             if let (Some(BasicValueEnum::IntValue(l)), Some(InterData::Int(r))) =
                                 (lhs.value(ctx), &rhs.inter_val)
                             {
-                                Some(
-                                    ctx.builder
-                                        .build_int_compare(
-                                            NE,
-                                            l,
-                                            ctx.context
-                                                .custom_width_int_type(self.bits() as _)
-                                                .const_int(*r as _, self.is_signed()),
-                                            "",
-                                        )
-                                        .into(),
-                                )
+                                ctx.builder
+                                    .build_int_compare(
+                                        NE,
+                                        l,
+                                        ctx.context
+                                            .custom_width_int_type(self.bits() as _)
+                                            .const_int(*r as _, self.is_signed()),
+                                        "",
+                                    )
+                                    .ok()
+                                    .map(From::from)
                             } else {
                                 None
                             },
@@ -1158,17 +1158,16 @@ impl Type for Int {
                     if let (Some(InterData::Int(l)), Some(BasicValueEnum::IntValue(r))) =
                         (&lhs.inter_val, rhs.value(ctx))
                     {
-                        Some(
-                            ctx.builder
-                                .build_int_add(
-                                    ctx.context
-                                        .custom_width_int_type(self.bits() as _)
-                                        .const_int(*l as _, self.is_signed()),
-                                    r,
-                                    "",
-                                )
-                                .into(),
-                        )
+                        ctx.builder
+                            .build_int_add(
+                                ctx.context
+                                    .custom_width_int_type(self.bits() as _)
+                                    .const_int(*l as _, self.is_signed()),
+                                r,
+                                "",
+                            )
+                            .ok()
+                            .map(From::from)
                     } else {
                         None
                     },
@@ -1185,17 +1184,16 @@ impl Type for Int {
                     if let (Some(InterData::Int(l)), Some(BasicValueEnum::IntValue(r))) =
                         (&lhs.inter_val, rhs.value(ctx))
                     {
-                        Some(
-                            ctx.builder
-                                .build_int_sub(
-                                    ctx.context
-                                        .custom_width_int_type(self.bits() as _)
-                                        .const_int(*l as _, self.is_signed()),
-                                    r,
-                                    "",
-                                )
-                                .into(),
-                        )
+                        ctx.builder
+                            .build_int_sub(
+                                ctx.context
+                                    .custom_width_int_type(self.bits() as _)
+                                    .const_int(*l as _, self.is_signed()),
+                                r,
+                                "",
+                            )
+                            .ok()
+                            .map(From::from)
                     } else {
                         None
                     },
@@ -1212,17 +1210,16 @@ impl Type for Int {
                     if let (Some(InterData::Int(l)), Some(BasicValueEnum::IntValue(r))) =
                         (&lhs.inter_val, rhs.value(ctx))
                     {
-                        Some(
-                            ctx.builder
-                                .build_int_mul(
-                                    ctx.context
-                                        .custom_width_int_type(self.bits() as _)
-                                        .const_int(*l as _, self.is_signed()),
-                                    r,
-                                    "",
-                                )
-                                .into(),
-                        )
+                        ctx.builder
+                            .build_int_mul(
+                                ctx.context
+                                    .custom_width_int_type(self.bits() as _)
+                                    .const_int(*l as _, self.is_signed()),
+                                r,
+                                "",
+                            )
+                            .ok()
+                            .map(From::from)
                     } else {
                         None
                     },
@@ -1243,14 +1240,13 @@ impl Type for Int {
                             .context
                             .custom_width_int_type(self.bits() as _)
                             .const_int(*l as _, self.is_signed());
-                        Some(
-                            if self.is_signed() {
-                                ctx.builder.build_int_signed_div(l, r, "")
-                            } else {
-                                ctx.builder.build_int_unsigned_div(l, r, "")
-                            }
-                            .into(),
-                        )
+                        if self.is_signed() {
+                            ctx.builder.build_int_signed_div(l, r, "")
+                        } else {
+                            ctx.builder.build_int_unsigned_div(l, r, "")
+                        }
+                        .ok()
+                        .map(From::from)
                     } else {
                         None
                     },
@@ -1271,14 +1267,13 @@ impl Type for Int {
                             .context
                             .custom_width_int_type(self.bits() as _)
                             .const_int(*l as _, self.is_signed());
-                        Some(
-                            if self.is_signed() {
-                                ctx.builder.build_int_signed_rem(l, r, "")
-                            } else {
-                                ctx.builder.build_int_unsigned_rem(l, r, "")
-                            }
-                            .into(),
-                        )
+                        if self.is_signed() {
+                            ctx.builder.build_int_signed_rem(l, r, "")
+                        } else {
+                            ctx.builder.build_int_unsigned_rem(l, r, "")
+                        }
+                        .ok()
+                        .map(From::from)
                     } else {
                         None
                     },
@@ -1295,17 +1290,16 @@ impl Type for Int {
                     if let (Some(InterData::Int(l)), Some(BasicValueEnum::IntValue(r))) =
                         (&lhs.inter_val, rhs.value(ctx))
                     {
-                        Some(
-                            ctx.builder
-                                .build_and(
-                                    ctx.context
-                                        .custom_width_int_type(self.bits() as _)
-                                        .const_int(*l as _, self.is_signed()),
-                                    r,
-                                    "",
-                                )
-                                .into(),
-                        )
+                        ctx.builder
+                            .build_and(
+                                ctx.context
+                                    .custom_width_int_type(self.bits() as _)
+                                    .const_int(*l as _, self.is_signed()),
+                                r,
+                                "",
+                            )
+                            .ok()
+                            .map(From::from)
                     } else {
                         None
                     },
@@ -1322,17 +1316,16 @@ impl Type for Int {
                     if let (Some(InterData::Int(l)), Some(BasicValueEnum::IntValue(r))) =
                         (&lhs.inter_val, rhs.value(ctx))
                     {
-                        Some(
-                            ctx.builder
-                                .build_or(
-                                    ctx.context
-                                        .custom_width_int_type(self.bits() as _)
-                                        .const_int(*l as _, self.is_signed()),
-                                    r,
-                                    "",
-                                )
-                                .into(),
-                        )
+                        ctx.builder
+                            .build_or(
+                                ctx.context
+                                    .custom_width_int_type(self.bits() as _)
+                                    .const_int(*l as _, self.is_signed()),
+                                r,
+                                "",
+                            )
+                            .ok()
+                            .map(From::from)
                     } else {
                         None
                     },
@@ -1349,17 +1342,16 @@ impl Type for Int {
                     if let (Some(InterData::Int(l)), Some(BasicValueEnum::IntValue(r))) =
                         (&lhs.inter_val, rhs.value(ctx))
                     {
-                        Some(
-                            ctx.builder
-                                .build_xor(
-                                    ctx.context
-                                        .custom_width_int_type(self.bits() as _)
-                                        .const_int(*l as _, self.is_signed()),
-                                    r,
-                                    "",
-                                )
-                                .into(),
-                        )
+                        ctx.builder
+                            .build_xor(
+                                ctx.context
+                                    .custom_width_int_type(self.bits() as _)
+                                    .const_int(*l as _, self.is_signed()),
+                                r,
+                                "",
+                            )
+                            .ok()
+                            .map(From::from)
                     } else {
                         None
                     },
@@ -1376,17 +1368,16 @@ impl Type for Int {
                     if let (Some(InterData::Int(l)), Some(BasicValueEnum::IntValue(r))) =
                         (&lhs.inter_val, rhs.value(ctx))
                     {
-                        Some(
-                            ctx.builder
-                                .build_left_shift(
-                                    ctx.context
-                                        .custom_width_int_type(self.bits() as _)
-                                        .const_int(*l as _, self.is_signed()),
-                                    r,
-                                    "",
-                                )
-                                .into(),
-                        )
+                        ctx.builder
+                            .build_left_shift(
+                                ctx.context
+                                    .custom_width_int_type(self.bits() as _)
+                                    .const_int(*l as _, self.is_signed()),
+                                r,
+                                "",
+                            )
+                            .ok()
+                            .map(From::from)
                     } else {
                         None
                     },
@@ -1403,18 +1394,17 @@ impl Type for Int {
                     if let (Some(InterData::Int(l)), Some(BasicValueEnum::IntValue(r))) =
                         (&lhs.inter_val, rhs.value(ctx))
                     {
-                        Some(
-                            ctx.builder
-                                .build_right_shift(
-                                    ctx.context
-                                        .custom_width_int_type(self.bits() as _)
-                                        .const_int(*l as _, self.is_signed()),
-                                    r,
-                                    self.is_signed(),
-                                    "",
-                                )
-                                .into(),
-                        )
+                        ctx.builder
+                            .build_right_shift(
+                                ctx.context
+                                    .custom_width_int_type(self.bits() as _)
+                                    .const_int(*l as _, self.is_signed()),
+                                r,
+                                self.is_signed(),
+                                "",
+                            )
+                            .ok()
+                            .map(From::from)
                     } else {
                         None
                     },
@@ -1431,18 +1421,17 @@ impl Type for Int {
                     if let (Some(InterData::Int(l)), Some(BasicValueEnum::IntValue(r))) =
                         (&lhs.inter_val, rhs.value(ctx))
                     {
-                        Some(
-                            ctx.builder
-                                .build_int_compare(
-                                    if self.is_signed() { SLT } else { ULT },
-                                    ctx.context
-                                        .custom_width_int_type(self.bits() as _)
-                                        .const_int(*l as _, self.is_signed()),
-                                    r,
-                                    "",
-                                )
-                                .into(),
-                        )
+                        ctx.builder
+                            .build_int_compare(
+                                if self.is_signed() { SLT } else { ULT },
+                                ctx.context
+                                    .custom_width_int_type(self.bits() as _)
+                                    .const_int(*l as _, self.is_signed()),
+                                r,
+                                "",
+                            )
+                            .ok()
+                            .map(From::from)
                     } else {
                         None
                     },
@@ -1459,18 +1448,17 @@ impl Type for Int {
                     if let (Some(InterData::Int(l)), Some(BasicValueEnum::IntValue(r))) =
                         (&lhs.inter_val, rhs.value(ctx))
                     {
-                        Some(
-                            ctx.builder
-                                .build_int_compare(
-                                    if self.is_signed() { SGT } else { UGT },
-                                    ctx.context
-                                        .custom_width_int_type(self.bits() as _)
-                                        .const_int(*l as _, self.is_signed()),
-                                    r,
-                                    "",
-                                )
-                                .into(),
-                        )
+                        ctx.builder
+                            .build_int_compare(
+                                if self.is_signed() { SGT } else { UGT },
+                                ctx.context
+                                    .custom_width_int_type(self.bits() as _)
+                                    .const_int(*l as _, self.is_signed()),
+                                r,
+                                "",
+                            )
+                            .ok()
+                            .map(From::from)
                     } else {
                         None
                     },
@@ -1487,18 +1475,17 @@ impl Type for Int {
                     if let (Some(InterData::Int(l)), Some(BasicValueEnum::IntValue(r))) =
                         (&lhs.inter_val, rhs.value(ctx))
                     {
-                        Some(
-                            ctx.builder
-                                .build_int_compare(
-                                    if self.is_signed() { SLE } else { ULE },
-                                    ctx.context
-                                        .custom_width_int_type(self.bits() as _)
-                                        .const_int(*l as _, self.is_signed()),
-                                    r,
-                                    "",
-                                )
-                                .into(),
-                        )
+                        ctx.builder
+                            .build_int_compare(
+                                if self.is_signed() { SLE } else { ULE },
+                                ctx.context
+                                    .custom_width_int_type(self.bits() as _)
+                                    .const_int(*l as _, self.is_signed()),
+                                r,
+                                "",
+                            )
+                            .ok()
+                            .map(From::from)
                     } else {
                         None
                     },
@@ -1515,18 +1502,17 @@ impl Type for Int {
                     if let (Some(InterData::Int(l)), Some(BasicValueEnum::IntValue(r))) =
                         (&lhs.inter_val, rhs.value(ctx))
                     {
-                        Some(
-                            ctx.builder
-                                .build_int_compare(
-                                    if self.is_signed() { SGE } else { UGE },
-                                    ctx.context
-                                        .custom_width_int_type(self.bits() as _)
-                                        .const_int(*l as _, self.is_signed()),
-                                    r,
-                                    "",
-                                )
-                                .into(),
-                        )
+                        ctx.builder
+                            .build_int_compare(
+                                if self.is_signed() { SGE } else { UGE },
+                                ctx.context
+                                    .custom_width_int_type(self.bits() as _)
+                                    .const_int(*l as _, self.is_signed()),
+                                r,
+                                "",
+                            )
+                            .ok()
+                            .map(From::from)
                     } else {
                         None
                     },
@@ -1543,18 +1529,17 @@ impl Type for Int {
                     if let (Some(InterData::Int(l)), Some(BasicValueEnum::IntValue(r))) =
                         (&lhs.inter_val, rhs.value(ctx))
                     {
-                        Some(
-                            ctx.builder
-                                .build_int_compare(
-                                    EQ,
-                                    ctx.context
-                                        .custom_width_int_type(self.bits() as _)
-                                        .const_int(*l as _, self.is_signed()),
-                                    r,
-                                    "",
-                                )
-                                .into(),
-                        )
+                        ctx.builder
+                            .build_int_compare(
+                                EQ,
+                                ctx.context
+                                    .custom_width_int_type(self.bits() as _)
+                                    .const_int(*l as _, self.is_signed()),
+                                r,
+                                "",
+                            )
+                            .ok()
+                            .map(From::from)
                     } else {
                         None
                     },
@@ -1571,18 +1556,17 @@ impl Type for Int {
                     if let (Some(InterData::Int(l)), Some(BasicValueEnum::IntValue(r))) =
                         (&lhs.inter_val, rhs.value(ctx))
                     {
-                        Some(
-                            ctx.builder
-                                .build_int_compare(
-                                    NE,
-                                    ctx.context
-                                        .custom_width_int_type(self.bits() as _)
-                                        .const_int(*l as _, self.is_signed()),
-                                    r,
-                                    "",
-                                )
-                                .into(),
-                        )
+                        ctx.builder
+                            .build_int_compare(
+                                NE,
+                                ctx.context
+                                    .custom_width_int_type(self.bits() as _)
+                                    .const_int(*l as _, self.is_signed()),
+                                r,
+                                "",
+                            )
+                            .ok()
+                            .map(From::from)
                     } else {
                         None
                     },
@@ -1616,8 +1600,11 @@ impl Type for Int {
             "++" => Ok(Value::new(
                 if let Some(BasicValueEnum::PointerValue(pv)) = val.comp_val {
                     let it = self.llvm_type(ctx).unwrap().into_int_type();
-                    let v1 = ctx.builder.build_load(it, pv, "").into_int_value();
-                    let v2 = ctx.builder.build_int_add(v1, it.const_int(1, false), "");
+                    let v1 = ctx.builder.build_load(it, pv, "").unwrap().into_int_value();
+                    let v2 = ctx
+                        .builder
+                        .build_int_add(v1, it.const_int(1, false), "")
+                        .unwrap();
                     ctx.builder.build_store(pv, v2);
                     val.comp_val
                 } else {
@@ -1629,8 +1616,11 @@ impl Type for Int {
             "--" => Ok(Value::new(
                 if let Some(BasicValueEnum::PointerValue(pv)) = val.comp_val {
                     let it = self.llvm_type(ctx).unwrap().into_int_type();
-                    let v1 = ctx.builder.build_load(it, pv, "").into_int_value();
-                    let v2 = ctx.builder.build_int_sub(v1, it.const_int(1, false), "");
+                    let v1 = ctx.builder.build_load(it, pv, "").unwrap().into_int_value();
+                    let v2 = ctx
+                        .builder
+                        .build_int_sub(v1, it.const_int(1, false), "")
+                        .unwrap();
                     ctx.builder.build_store(pv, v2);
                     val.comp_val
                 } else {
@@ -1671,61 +1661,106 @@ impl Type for Int {
                     let rv = lty.const_int(*v as _, self.is_signed());
                     match op.0 {
                         "+=" => {
-                            let v1 = ctx.builder.build_load(lty, lv, "").into_int_value();
-                            let v2 = ctx.builder.build_int_add(v1, rv, "");
+                            let v1 = ctx
+                                .builder
+                                .build_load(lty, lv, "")
+                                .unwrap()
+                                .into_int_value();
+                            let v2 = ctx.builder.build_int_add(v1, rv, "").unwrap();
                             ctx.builder.build_store(lv, v2);
                         }
                         "-=" => {
-                            let v1 = ctx.builder.build_load(lty, lv, "").into_int_value();
-                            let v2 = ctx.builder.build_int_sub(v1, rv, "");
+                            let v1 = ctx
+                                .builder
+                                .build_load(lty, lv, "")
+                                .unwrap()
+                                .into_int_value();
+                            let v2 = ctx.builder.build_int_sub(v1, rv, "").unwrap();
                             ctx.builder.build_store(lv, v2);
                         }
                         "*=" => {
-                            let v1 = ctx.builder.build_load(lty, lv, "").into_int_value();
-                            let v2 = ctx.builder.build_int_mul(v1, rv, "");
+                            let v1 = ctx
+                                .builder
+                                .build_load(lty, lv, "")
+                                .unwrap()
+                                .into_int_value();
+                            let v2 = ctx.builder.build_int_mul(v1, rv, "").unwrap();
                             ctx.builder.build_store(lv, v2);
                         }
                         "/=" => {
-                            let v1 = ctx.builder.build_load(lty, lv, "").into_int_value();
+                            let v1 = ctx
+                                .builder
+                                .build_load(lty, lv, "")
+                                .unwrap()
+                                .into_int_value();
                             let v2 = if self.is_signed() {
                                 ctx.builder.build_int_signed_div(v1, rv, "")
                             } else {
                                 ctx.builder.build_int_unsigned_div(v1, rv, "")
-                            };
+                            }
+                            .unwrap();
                             ctx.builder.build_store(lv, v2);
                         }
                         "%=" => {
-                            let v1 = ctx.builder.build_load(lty, lv, "").into_int_value();
+                            let v1 = ctx
+                                .builder
+                                .build_load(lty, lv, "")
+                                .unwrap()
+                                .into_int_value();
                             let v2 = if self.is_signed() {
                                 ctx.builder.build_int_signed_rem(v1, rv, "")
                             } else {
                                 ctx.builder.build_int_unsigned_rem(v1, rv, "")
-                            };
+                            }
+                            .unwrap();
                             ctx.builder.build_store(lv, v2);
                         }
                         "&=" => {
-                            let v1 = ctx.builder.build_load(lty, lv, "").into_int_value();
-                            let v2 = ctx.builder.build_and(v1, rv, "");
+                            let v1 = ctx
+                                .builder
+                                .build_load(lty, lv, "")
+                                .unwrap()
+                                .into_int_value();
+                            let v2 = ctx.builder.build_and(v1, rv, "").unwrap();
                             ctx.builder.build_store(lv, v2);
                         }
                         "|=" => {
-                            let v1 = ctx.builder.build_load(lty, lv, "").into_int_value();
-                            let v2 = ctx.builder.build_or(v1, rv, "");
+                            let v1 = ctx
+                                .builder
+                                .build_load(lty, lv, "")
+                                .unwrap()
+                                .into_int_value();
+                            let v2 = ctx.builder.build_or(v1, rv, "").unwrap();
                             ctx.builder.build_store(lv, v2);
                         }
                         "^=" => {
-                            let v1 = ctx.builder.build_load(lty, lv, "").into_int_value();
-                            let v2 = ctx.builder.build_xor(v1, rv, "");
+                            let v1 = ctx
+                                .builder
+                                .build_load(lty, lv, "")
+                                .unwrap()
+                                .into_int_value();
+                            let v2 = ctx.builder.build_xor(v1, rv, "").unwrap();
                             ctx.builder.build_store(lv, v2);
                         }
                         "<<=" => {
-                            let v1 = ctx.builder.build_load(lty, lv, "").into_int_value();
-                            let v2 = ctx.builder.build_left_shift(v1, rv, "");
+                            let v1 = ctx
+                                .builder
+                                .build_load(lty, lv, "")
+                                .unwrap()
+                                .into_int_value();
+                            let v2 = ctx.builder.build_left_shift(v1, rv, "").unwrap();
                             ctx.builder.build_store(lv, v2);
                         }
                         ">>=" => {
-                            let v1 = ctx.builder.build_load(lty, lv, "").into_int_value();
-                            let v2 = ctx.builder.build_right_shift(v1, rv, self.is_signed(), "");
+                            let v1 = ctx
+                                .builder
+                                .build_load(lty, lv, "")
+                                .unwrap()
+                                .into_int_value();
+                            let v2 = ctx
+                                .builder
+                                .build_right_shift(v1, rv, self.is_signed(), "")
+                                .unwrap();
                             ctx.builder.build_store(lv, v2);
                         }
                         _ => return Err(invalid_binop(&lhs, &rhs, op.0, op.1)),
@@ -1766,66 +1801,112 @@ impl Type for Int {
                             } else {
                                 ctx.builder.build_int_z_extend(rv, lty, "")
                             }
+                            .unwrap()
                         }
                         Ordering::Equal => {}
                     }
                     match op.0 {
                         "+=" => {
-                            let v1 = ctx.builder.build_load(lty, lv, "").into_int_value();
-                            let v2 = ctx.builder.build_int_add(v1, rv, "");
+                            let v1 = ctx
+                                .builder
+                                .build_load(lty, lv, "")
+                                .unwrap()
+                                .into_int_value();
+                            let v2 = ctx.builder.build_int_add(v1, rv, "").unwrap();
                             ctx.builder.build_store(lv, v2);
                         }
                         "-=" => {
-                            let v1 = ctx.builder.build_load(lty, lv, "").into_int_value();
-                            let v2 = ctx.builder.build_int_sub(v1, rv, "");
+                            let v1 = ctx
+                                .builder
+                                .build_load(lty, lv, "")
+                                .unwrap()
+                                .into_int_value();
+                            let v2 = ctx.builder.build_int_sub(v1, rv, "").unwrap();
                             ctx.builder.build_store(lv, v2);
                         }
                         "*=" => {
-                            let v1 = ctx.builder.build_load(lty, lv, "").into_int_value();
-                            let v2 = ctx.builder.build_int_mul(v1, rv, "");
+                            let v1 = ctx
+                                .builder
+                                .build_load(lty, lv, "")
+                                .unwrap()
+                                .into_int_value();
+                            let v2 = ctx.builder.build_int_mul(v1, rv, "").unwrap();
                             ctx.builder.build_store(lv, v2);
                         }
                         "/=" => {
-                            let v1 = ctx.builder.build_load(lty, lv, "").into_int_value();
+                            let v1 = ctx
+                                .builder
+                                .build_load(lty, lv, "")
+                                .unwrap()
+                                .into_int_value();
                             let v2 = if self.is_signed() {
                                 ctx.builder.build_int_signed_div(v1, rv, "")
                             } else {
                                 ctx.builder.build_int_unsigned_div(v1, rv, "")
-                            };
+                            }
+                            .unwrap();
                             ctx.builder.build_store(lv, v2);
                         }
                         "%=" => {
-                            let v1 = ctx.builder.build_load(lty, lv, "").into_int_value();
+                            let v1 = ctx
+                                .builder
+                                .build_load(lty, lv, "")
+                                .unwrap()
+                                .into_int_value();
                             let v2 = if self.is_signed() {
                                 ctx.builder.build_int_signed_rem(v1, rv, "")
                             } else {
                                 ctx.builder.build_int_unsigned_rem(v1, rv, "")
-                            };
+                            }
+                            .unwrap();
                             ctx.builder.build_store(lv, v2);
                         }
                         "&=" => {
-                            let v1 = ctx.builder.build_load(lty, lv, "").into_int_value();
-                            let v2 = ctx.builder.build_and(v1, rv, "");
+                            let v1 = ctx
+                                .builder
+                                .build_load(lty, lv, "")
+                                .unwrap()
+                                .into_int_value();
+                            let v2 = ctx.builder.build_and(v1, rv, "").unwrap();
                             ctx.builder.build_store(lv, v2);
                         }
                         "|=" => {
-                            let v1 = ctx.builder.build_load(lty, lv, "").into_int_value();
-                            let v2 = ctx.builder.build_or(v1, rv, "");
+                            let v1 = ctx
+                                .builder
+                                .build_load(lty, lv, "")
+                                .unwrap()
+                                .into_int_value();
+                            let v2 = ctx.builder.build_or(v1, rv, "").unwrap();
                             ctx.builder.build_store(lv, v2);
                         }
                         "^=" => {
-                            let v1 = ctx.builder.build_load(lty, lv, "").into_int_value();
-                            let v2 = ctx.builder.build_xor(v1, rv, "");
+                            let v1 = ctx
+                                .builder
+                                .build_load(lty, lv, "")
+                                .unwrap()
+                                .into_int_value();
+                            let v2 = ctx.builder.build_xor(v1, rv, "").unwrap();
                             ctx.builder.build_store(lv, v2);
                         }
                         "<<=" => {
-                            let v1 = ctx.builder.build_load(lty, lv, "").into_int_value();
-                            let v2 = ctx.builder.build_left_shift(v1, rv, "");
+                            let v1 = ctx
+                                .builder
+                                .build_load(lty, lv, "")
+                                .unwrap()
+                                .into_int_value();
+                            let v2 = ctx.builder.build_left_shift(v1, rv, "").unwrap();
                             ctx.builder.build_store(lv, v2);
                         }
                         ">>=" => {
-                            let v1 = ctx.builder.build_load(lty, lv, "").into_int_value();
-                            let v2 = ctx.builder.build_right_shift(v1, rv, self.is_signed(), "");
+                            let v1 = ctx
+                                .builder
+                                .build_load(lty, lv, "")
+                                .unwrap()
+                                .into_int_value();
+                            let v2 = ctx
+                                .builder
+                                .build_right_shift(v1, rv, self.is_signed(), "")
+                                .unwrap();
                             ctx.builder.build_store(lv, v2);
                         }
                         _ => return Err(invalid_binop(&lhs, &rhs, op.0, op.1)),
@@ -1895,7 +1976,7 @@ impl Type for IntLiteral {
             "+" => Ok(val),
             "-" => Ok(Value {
                 comp_val: if let Some(BasicValueEnum::IntValue(v)) = val.comp_val {
-                    Some(ctx.builder.build_int_neg(v, "").into())
+                    ctx.builder.build_int_neg(v, "").ok().map(From::from)
                 } else {
                     None
                 },
@@ -1908,7 +1989,7 @@ impl Type for IntLiteral {
             }),
             "~" => Ok(Value {
                 comp_val: if let Some(BasicValueEnum::IntValue(v)) = val.value(ctx) {
-                    Some(ctx.builder.build_not(v, "").into())
+                    ctx.builder.build_not(v, "").ok().map(From::from)
                 } else {
                     None
                 },
@@ -1921,11 +2002,10 @@ impl Type for IntLiteral {
             }),
             "!" => Ok(Value::new(
                 if let Some(BasicValueEnum::IntValue(v)) = val.value(ctx) {
-                    Some(
-                        ctx.builder
-                            .build_int_compare(EQ, v, v.get_type().const_zero(), "")
-                            .into(),
-                    )
+                    ctx.builder
+                        .build_int_compare(EQ, v, v.get_type().const_zero(), "")
+                        .ok()
+                        .map(From::from)
                 } else {
                     None
                 },

--- a/cobalt-ast/src/types/int.rs
+++ b/cobalt-ast/src/types/int.rs
@@ -1605,7 +1605,7 @@ impl Type for Int {
                         .builder
                         .build_int_add(v1, it.const_int(1, false), "")
                         .unwrap();
-                    ctx.builder.build_store(pv, v2);
+                    ctx.builder.build_store(pv, v2).unwrap();
                     val.comp_val
                 } else {
                     None
@@ -1621,7 +1621,7 @@ impl Type for Int {
                         .builder
                         .build_int_sub(v1, it.const_int(1, false), "")
                         .unwrap();
-                    ctx.builder.build_store(pv, v2);
+                    ctx.builder.build_store(pv, v2).unwrap();
                     val.comp_val
                 } else {
                     None
@@ -1667,7 +1667,7 @@ impl Type for Int {
                                 .unwrap()
                                 .into_int_value();
                             let v2 = ctx.builder.build_int_add(v1, rv, "").unwrap();
-                            ctx.builder.build_store(lv, v2);
+                            ctx.builder.build_store(lv, v2).unwrap();
                         }
                         "-=" => {
                             let v1 = ctx
@@ -1676,7 +1676,7 @@ impl Type for Int {
                                 .unwrap()
                                 .into_int_value();
                             let v2 = ctx.builder.build_int_sub(v1, rv, "").unwrap();
-                            ctx.builder.build_store(lv, v2);
+                            ctx.builder.build_store(lv, v2).unwrap();
                         }
                         "*=" => {
                             let v1 = ctx
@@ -1685,7 +1685,7 @@ impl Type for Int {
                                 .unwrap()
                                 .into_int_value();
                             let v2 = ctx.builder.build_int_mul(v1, rv, "").unwrap();
-                            ctx.builder.build_store(lv, v2);
+                            ctx.builder.build_store(lv, v2).unwrap();
                         }
                         "/=" => {
                             let v1 = ctx
@@ -1699,7 +1699,7 @@ impl Type for Int {
                                 ctx.builder.build_int_unsigned_div(v1, rv, "")
                             }
                             .unwrap();
-                            ctx.builder.build_store(lv, v2);
+                            ctx.builder.build_store(lv, v2).unwrap();
                         }
                         "%=" => {
                             let v1 = ctx
@@ -1713,7 +1713,7 @@ impl Type for Int {
                                 ctx.builder.build_int_unsigned_rem(v1, rv, "")
                             }
                             .unwrap();
-                            ctx.builder.build_store(lv, v2);
+                            ctx.builder.build_store(lv, v2).unwrap();
                         }
                         "&=" => {
                             let v1 = ctx
@@ -1722,7 +1722,7 @@ impl Type for Int {
                                 .unwrap()
                                 .into_int_value();
                             let v2 = ctx.builder.build_and(v1, rv, "").unwrap();
-                            ctx.builder.build_store(lv, v2);
+                            ctx.builder.build_store(lv, v2).unwrap();
                         }
                         "|=" => {
                             let v1 = ctx
@@ -1731,7 +1731,7 @@ impl Type for Int {
                                 .unwrap()
                                 .into_int_value();
                             let v2 = ctx.builder.build_or(v1, rv, "").unwrap();
-                            ctx.builder.build_store(lv, v2);
+                            ctx.builder.build_store(lv, v2).unwrap();
                         }
                         "^=" => {
                             let v1 = ctx
@@ -1740,7 +1740,7 @@ impl Type for Int {
                                 .unwrap()
                                 .into_int_value();
                             let v2 = ctx.builder.build_xor(v1, rv, "").unwrap();
-                            ctx.builder.build_store(lv, v2);
+                            ctx.builder.build_store(lv, v2).unwrap();
                         }
                         "<<=" => {
                             let v1 = ctx
@@ -1749,7 +1749,7 @@ impl Type for Int {
                                 .unwrap()
                                 .into_int_value();
                             let v2 = ctx.builder.build_left_shift(v1, rv, "").unwrap();
-                            ctx.builder.build_store(lv, v2);
+                            ctx.builder.build_store(lv, v2).unwrap();
                         }
                         ">>=" => {
                             let v1 = ctx
@@ -1761,7 +1761,7 @@ impl Type for Int {
                                 .builder
                                 .build_right_shift(v1, rv, self.is_signed(), "")
                                 .unwrap();
-                            ctx.builder.build_store(lv, v2);
+                            ctx.builder.build_store(lv, v2).unwrap();
                         }
                         _ => return Err(invalid_binop(&lhs, &rhs, op.0, op.1)),
                     }
@@ -1813,7 +1813,7 @@ impl Type for Int {
                                 .unwrap()
                                 .into_int_value();
                             let v2 = ctx.builder.build_int_add(v1, rv, "").unwrap();
-                            ctx.builder.build_store(lv, v2);
+                            ctx.builder.build_store(lv, v2).unwrap();
                         }
                         "-=" => {
                             let v1 = ctx
@@ -1822,7 +1822,7 @@ impl Type for Int {
                                 .unwrap()
                                 .into_int_value();
                             let v2 = ctx.builder.build_int_sub(v1, rv, "").unwrap();
-                            ctx.builder.build_store(lv, v2);
+                            ctx.builder.build_store(lv, v2).unwrap();
                         }
                         "*=" => {
                             let v1 = ctx
@@ -1831,7 +1831,7 @@ impl Type for Int {
                                 .unwrap()
                                 .into_int_value();
                             let v2 = ctx.builder.build_int_mul(v1, rv, "").unwrap();
-                            ctx.builder.build_store(lv, v2);
+                            ctx.builder.build_store(lv, v2).unwrap();
                         }
                         "/=" => {
                             let v1 = ctx
@@ -1845,7 +1845,7 @@ impl Type for Int {
                                 ctx.builder.build_int_unsigned_div(v1, rv, "")
                             }
                             .unwrap();
-                            ctx.builder.build_store(lv, v2);
+                            ctx.builder.build_store(lv, v2).unwrap();
                         }
                         "%=" => {
                             let v1 = ctx
@@ -1859,7 +1859,7 @@ impl Type for Int {
                                 ctx.builder.build_int_unsigned_rem(v1, rv, "")
                             }
                             .unwrap();
-                            ctx.builder.build_store(lv, v2);
+                            ctx.builder.build_store(lv, v2).unwrap();
                         }
                         "&=" => {
                             let v1 = ctx
@@ -1868,7 +1868,7 @@ impl Type for Int {
                                 .unwrap()
                                 .into_int_value();
                             let v2 = ctx.builder.build_and(v1, rv, "").unwrap();
-                            ctx.builder.build_store(lv, v2);
+                            ctx.builder.build_store(lv, v2).unwrap();
                         }
                         "|=" => {
                             let v1 = ctx
@@ -1877,7 +1877,7 @@ impl Type for Int {
                                 .unwrap()
                                 .into_int_value();
                             let v2 = ctx.builder.build_or(v1, rv, "").unwrap();
-                            ctx.builder.build_store(lv, v2);
+                            ctx.builder.build_store(lv, v2).unwrap();
                         }
                         "^=" => {
                             let v1 = ctx
@@ -1886,7 +1886,7 @@ impl Type for Int {
                                 .unwrap()
                                 .into_int_value();
                             let v2 = ctx.builder.build_xor(v1, rv, "").unwrap();
-                            ctx.builder.build_store(lv, v2);
+                            ctx.builder.build_store(lv, v2).unwrap();
                         }
                         "<<=" => {
                             let v1 = ctx
@@ -1895,7 +1895,7 @@ impl Type for Int {
                                 .unwrap()
                                 .into_int_value();
                             let v2 = ctx.builder.build_left_shift(v1, rv, "").unwrap();
-                            ctx.builder.build_store(lv, v2);
+                            ctx.builder.build_store(lv, v2).unwrap();
                         }
                         ">>=" => {
                             let v1 = ctx
@@ -1907,7 +1907,7 @@ impl Type for Int {
                                 .builder
                                 .build_right_shift(v1, rv, self.is_signed(), "")
                                 .unwrap();
-                            ctx.builder.build_store(lv, v2);
+                            ctx.builder.build_store(lv, v2).unwrap();
                         }
                         _ => return Err(invalid_binop(&lhs, &rhs, op.0, op.1)),
                     }

--- a/cobalt-ast/src/types/intrinsic.rs
+++ b/cobalt-ast/src/types/intrinsic.rs
@@ -317,6 +317,7 @@ impl Type for InlineAsm {
             Ok(Value::new(
                 ctx.builder
                     .build_indirect_call(fty, asm, &comp_args, "")
+                    .unwrap()
                     .try_as_basic_value()
                     .left(),
                 None,
@@ -330,6 +331,7 @@ impl Type for InlineAsm {
             Ok(Value::new(
                 ctx.builder
                     .build_indirect_call(fty, asm, &comp_args, "")
+                    .unwrap()
                     .try_as_basic_value()
                     .left(),
                 None,

--- a/cobalt-ast/src/types/mem.rs
+++ b/cobalt-ast/src/types/mem.rs
@@ -44,11 +44,13 @@ impl Type for Reference {
     ) -> Result<Value<'src, 'ctx>, CobaltError<'src>> {
         if !(ctx.is_const.get() || self.base().is::<types::Mut>()) {
             val.comp_val = val.comp_val.and_then(|v| {
-                Some(ctx.builder.build_load(
-                    self.base().llvm_type(ctx)?,
-                    v.is_pointer_value().then(|| v.into_pointer_value())?,
-                    "",
-                ))
+                ctx.builder
+                    .build_load(
+                        self.base().llvm_type(ctx)?,
+                        v.is_pointer_value().then(|| v.into_pointer_value())?,
+                        "",
+                    )
+                    .ok()
             });
         }
         self.base()
@@ -104,7 +106,7 @@ impl Type for Reference {
             if let (Some(BasicValueEnum::PointerValue(pv)), Some(val)) =
                 (lhs.comp_val, rhs.comp_val)
             {
-                let inst = ctx.builder.build_store(pv, val);
+                let inst = ctx.builder.build_store(pv, val).unwrap();
                 cfg::mark_move(&rhs, cfg::Location::Inst(inst, 0), ctx, rhs.loc);
             }
             return Ok(lhs);
@@ -116,7 +118,7 @@ impl Type for Reference {
                 lhs.value(ctx),
             ) {
                 lhs.address = Rc::new(Cell::new(Some(pv)));
-                Some(ctx.builder.build_load(llt, pv, ""))
+                ctx.builder.build_load(llt, pv, "").ok()
             } else {
                 None
             };
@@ -146,7 +148,7 @@ impl Type for Reference {
                 rhs.value(ctx),
             ) {
                 rhs.address = Rc::new(Cell::new(Some(pv)));
-                Some(ctx.builder.build_load(llt, pv, ""))
+                ctx.builder.build_load(llt, pv, "").ok()
             } else {
                 None
             };
@@ -218,7 +220,7 @@ impl Type for Reference {
                             base.base().llvm_type(ctx),
                             val.value(ctx),
                         ) {
-                            Some(ctx.builder.build_load(llt, pv, ""))
+                            ctx.builder.build_load(llt, pv, "").ok()
                         } else {
                             None
                         };
@@ -248,7 +250,7 @@ impl Type for Reference {
                     val.value(ctx),
                 ) {
                     val.address = Rc::new(Cell::new(Some(pv)));
-                    Some(ctx.builder.build_load(llt, pv, ""))
+                    ctx.builder.build_load(llt, pv, "").ok()
                 } else {
                     None
                 };
@@ -266,11 +268,13 @@ impl Type for Reference {
         } else if self.base().copyable(ctx) {
             if !(ctx.is_const.get() || self.base().is::<types::Mut>()) {
                 val.comp_val = val.comp_val.and_then(|v| {
-                    Some(ctx.builder.build_load(
-                        self.base().llvm_type(ctx)?,
-                        v.is_pointer_value().then(|| v.into_pointer_value())?,
-                        "",
-                    ))
+                    ctx.builder
+                        .build_load(
+                            self.base().llvm_type(ctx)?,
+                            v.is_pointer_value().then(|| v.into_pointer_value())?,
+                            "",
+                        )
+                        .ok()
                 })
             }
             val.data_type = self.base();
@@ -303,7 +307,7 @@ impl Type for Reference {
                     val.value(ctx),
                 ) {
                     val.address = Rc::new(Cell::new(Some(pv)));
-                    Some(ctx.builder.build_load(llt, pv, ""))
+                    ctx.builder.build_load(llt, pv, "").ok()
                 } else {
                     None
                 };
@@ -370,7 +374,7 @@ impl Type for Reference {
                     val.value(ctx),
                 ) {
                     val.address = Rc::new(Cell::new(Some(pv)));
-                    Some(ctx.builder.build_load(llt, pv, ""))
+                    ctx.builder.build_load(llt, pv, "").ok()
                 } else {
                     None
                 };
@@ -391,7 +395,7 @@ impl Type for Reference {
                 val.value(ctx),
             ) {
                 val.address = Rc::new(Cell::new(Some(pv)));
-                Some(ctx.builder.build_load(llt, pv, ""))
+                ctx.builder.build_load(llt, pv, "").ok()
             } else {
                 None
             };
@@ -472,16 +476,19 @@ impl Type for Pointer {
                             .ptr_type(ctx)
                             .map_or(false, BasicTypeEnum::is_pointer_type)
                         {
-                            let v1 =
-                                ctx.builder
-                                    .build_load(llt.ptr_type(Default::default()), pv, "");
+                            let v1 = ctx
+                                .builder
+                                .build_load(llt.ptr_type(Default::default()), pv, "")
+                                .unwrap();
                             let v2 = unsafe {
-                                ctx.builder.build_gep(
-                                    llt,
-                                    v1.into_pointer_value(),
-                                    &[ctx.context.i64_type().const_int(1, false)],
-                                    "",
-                                )
+                                ctx.builder
+                                    .build_gep(
+                                        llt,
+                                        v1.into_pointer_value(),
+                                        &[ctx.context.i64_type().const_int(1, false)],
+                                        "",
+                                    )
+                                    .unwrap()
                             };
                             ctx.builder.build_store(pv, v2);
                             val.comp_val
@@ -503,16 +510,19 @@ impl Type for Pointer {
                             .ptr_type(ctx)
                             .map_or(false, BasicTypeEnum::is_pointer_type)
                         {
-                            let v1 =
-                                ctx.builder
-                                    .build_load(llt.ptr_type(Default::default()), pv, "");
+                            let v1 = ctx
+                                .builder
+                                .build_load(llt.ptr_type(Default::default()), pv, "")
+                                .unwrap();
                             let v2 = unsafe {
-                                ctx.builder.build_gep(
-                                    llt,
-                                    v1.into_pointer_value(),
-                                    &[ctx.context.i64_type().const_all_ones()],
-                                    "",
-                                )
+                                ctx.builder
+                                    .build_gep(
+                                        llt,
+                                        v1.into_pointer_value(),
+                                        &[ctx.context.i64_type().const_all_ones()],
+                                        "",
+                                    )
+                                    .unwrap()
                             };
                             ctx.builder.build_store(pv, v2);
                             val.comp_val
@@ -584,8 +594,11 @@ impl Type for Pointer {
                                 ctx.builder.build_int_s_extend_or_bit_cast(v, i64ty, "")
                             } else {
                                 ctx.builder.build_int_z_extend_or_bit_cast(v, i64ty, "")
-                            };
-                            Some(unsafe { ctx.builder.build_gep(llt, pv, &[v], "") }.into())
+                            }
+                            .unwrap();
+                            unsafe { ctx.builder.build_gep(llt, pv, &[v], "") }
+                                .ok()
+                                .map(From::from)
                         } else {
                             None
                         },
@@ -608,9 +621,12 @@ impl Type for Pointer {
                                 ctx.builder.build_int_s_extend_or_bit_cast(v, i64ty, "")
                             } else {
                                 ctx.builder.build_int_z_extend_or_bit_cast(v, i64ty, "")
-                            };
-                            v = ctx.builder.build_int_neg(v, "");
-                            Some(unsafe { ctx.builder.build_gep(llt, pv, &[v], "") }.into())
+                            }
+                            .unwrap();
+                            v = ctx.builder.build_int_neg(v, "").unwrap();
+                            unsafe { ctx.builder.build_gep(llt, pv, &[v], "") }
+                                .ok()
+                                .map(From::from)
                         } else {
                             None
                         },
@@ -628,7 +644,10 @@ impl Type for Pointer {
                         Some(BasicValueEnum::PointerValue(r)),
                     ) = (self.base().llvm_type(ctx), lhs.comp_val, rhs.comp_val)
                     {
-                        Some(ctx.builder.build_ptr_diff(llt, l, r, "").into())
+                        ctx.builder
+                            .build_ptr_diff(llt, l, r, "")
+                            .ok()
+                            .map(From::from)
                     } else {
                         None
                     },
@@ -642,7 +661,10 @@ impl Type for Pointer {
                         Some(BasicValueEnum::PointerValue(r)),
                     ) = (self.base().llvm_type(ctx), lhs.comp_val, rhs.comp_val)
                     {
-                        Some(ctx.builder.build_int_compare(ULT, l, r, "").into())
+                        ctx.builder
+                            .build_int_compare(ULT, l, r, "")
+                            .ok()
+                            .map(From::from)
                     } else {
                         None
                     },
@@ -656,7 +678,10 @@ impl Type for Pointer {
                         Some(BasicValueEnum::PointerValue(r)),
                     ) = (self.base().llvm_type(ctx), lhs.comp_val, rhs.comp_val)
                     {
-                        Some(ctx.builder.build_int_compare(UGT, l, r, "").into())
+                        ctx.builder
+                            .build_int_compare(UGT, l, r, "")
+                            .ok()
+                            .map(From::from)
                     } else {
                         None
                     },
@@ -670,7 +695,10 @@ impl Type for Pointer {
                         Some(BasicValueEnum::PointerValue(r)),
                     ) = (self.base().llvm_type(ctx), lhs.comp_val, rhs.comp_val)
                     {
-                        Some(ctx.builder.build_int_compare(ULE, l, r, "").into())
+                        ctx.builder
+                            .build_int_compare(ULE, l, r, "")
+                            .ok()
+                            .map(From::from)
                     } else {
                         None
                     },
@@ -684,7 +712,10 @@ impl Type for Pointer {
                         Some(BasicValueEnum::PointerValue(r)),
                     ) = (self.base().llvm_type(ctx), lhs.comp_val, rhs.comp_val)
                     {
-                        Some(ctx.builder.build_int_compare(UGE, l, r, "").into())
+                        ctx.builder
+                            .build_int_compare(UGE, l, r, "")
+                            .ok()
+                            .map(From::from)
                     } else {
                         None
                     },
@@ -698,7 +729,10 @@ impl Type for Pointer {
                         Some(BasicValueEnum::PointerValue(r)),
                     ) = (self.base().llvm_type(ctx), lhs.comp_val, rhs.comp_val)
                     {
-                        Some(ctx.builder.build_int_compare(EQ, l, r, "").into())
+                        ctx.builder
+                            .build_int_compare(EQ, l, r, "")
+                            .ok()
+                            .map(From::from)
                     } else {
                         None
                     },
@@ -712,7 +746,10 @@ impl Type for Pointer {
                         Some(BasicValueEnum::PointerValue(r)),
                     ) = (self.base().llvm_type(ctx), lhs.comp_val, rhs.comp_val)
                     {
-                        Some(ctx.builder.build_int_compare(NE, l, r, "").into())
+                        ctx.builder
+                            .build_int_compare(NE, l, r, "")
+                            .ok()
+                            .map(From::from)
                     } else {
                         None
                     },
@@ -754,8 +791,11 @@ impl Type for Pointer {
                         ctx.builder.build_int_s_extend_or_bit_cast(v, i64ty, "")
                     } else {
                         ctx.builder.build_int_z_extend_or_bit_cast(v, i64ty, "")
-                    };
-                    Some(unsafe { ctx.builder.build_gep(llt, pv, &[v], "") }.into())
+                    }
+                    .unwrap();
+                    unsafe { ctx.builder.build_gep(llt, pv, &[v], "") }
+                        .ok()
+                        .map(From::from)
                 } else {
                     None
                 },
@@ -804,14 +844,22 @@ impl Type for Pointer {
                 let rv = lty.const_int(*rv as _, true);
                 match op.0 {
                     "+=" => {
-                        let v1 = ctx.builder.build_load(pt, lv, "").into_pointer_value();
-                        let v2 = unsafe { ctx.builder.build_gep(llt, v1, &[rv], "") };
+                        let v1 = ctx
+                            .builder
+                            .build_load(pt, lv, "")
+                            .unwrap()
+                            .into_pointer_value();
+                        let v2 = unsafe { ctx.builder.build_gep(llt, v1, &[rv], "") }.unwrap();
                         ctx.builder.build_store(lv, v2);
                     }
                     "-=" => {
-                        let v1 = ctx.builder.build_load(pt, lv, "").into_pointer_value();
-                        let v2 = ctx.builder.build_int_neg(v1, "");
-                        let v3 = unsafe { ctx.builder.build_gep(llt, v2, &[rv], "") };
+                        let v1 = ctx
+                            .builder
+                            .build_load(pt, lv, "")
+                            .unwrap()
+                            .into_pointer_value();
+                        let v2 = ctx.builder.build_int_neg(v1, "").unwrap();
+                        let v3 = unsafe { ctx.builder.build_gep(llt, v2, &[rv], "") }.unwrap();
                         ctx.builder.build_store(lv, v3);
                     }
                     _ => return Err(invalid_binop(&lhs, &rhs, op.0, op.1)),
@@ -833,18 +881,27 @@ impl Type for Pointer {
                         ctx.builder.build_int_s_extend(rv, lty, "")
                     } else {
                         ctx.builder.build_int_z_extend(rv, lty, "")
-                    };
+                    }
+                    .unwrap();
                 }
                 match op.0 {
                     "+=" => {
-                        let v1 = ctx.builder.build_load(pt, lv, "").into_pointer_value();
-                        let v2 = unsafe { ctx.builder.build_gep(llt, v1, &[rv], "") };
+                        let v1 = ctx
+                            .builder
+                            .build_load(pt, lv, "")
+                            .unwrap()
+                            .into_pointer_value();
+                        let v2 = unsafe { ctx.builder.build_gep(llt, v1, &[rv], "") }.unwrap();
                         ctx.builder.build_store(lv, v2);
                     }
                     "-=" => {
-                        let v1 = ctx.builder.build_load(pt, lv, "").into_pointer_value();
-                        let v2 = ctx.builder.build_int_neg(v1, "");
-                        let v3 = unsafe { ctx.builder.build_gep(llt, v2, &[rv], "") };
+                        let v1 = ctx
+                            .builder
+                            .build_load(pt, lv, "")
+                            .unwrap()
+                            .into_pointer_value();
+                        let v2 = ctx.builder.build_int_neg(v1, "").unwrap();
+                        let v3 = unsafe { ctx.builder.build_gep(llt, v2, &[rv], "") }.unwrap();
                         ctx.builder.build_store(lv, v3);
                     }
                     _ => return Err(invalid_binop(&lhs, &rhs, op.0, op.1)),
@@ -946,11 +1003,13 @@ impl Type for Mut {
         } else {
             if !ctx.is_const.get() {
                 val.comp_val = val.comp_val.and_then(|v| {
-                    Some(ctx.builder.build_load(
-                        self.base().llvm_type(ctx)?,
-                        v.is_pointer_value().then(|| v.into_pointer_value())?,
-                        "",
-                    ))
+                    ctx.builder
+                        .build_load(
+                            self.base().llvm_type(ctx)?,
+                            v.is_pointer_value().then(|| v.into_pointer_value())?,
+                            "",
+                        )
+                        .ok()
                 })
             }
             self.base().pre_op(val, op, oloc, ctx, can_move)
@@ -997,7 +1056,7 @@ impl Type for Mut {
             if let (Some(BasicValueEnum::PointerValue(pv)), Some(val)) =
                 (lhs.comp_val, rhs.comp_val)
             {
-                let inst = ctx.builder.build_store(pv, val);
+                let inst = ctx.builder.build_store(pv, val).unwrap();
                 cfg::mark_move(&rhs, cfg::Location::Inst(inst, 0), ctx, rhs.loc);
                 cfg::mark_store(&lhs, cfg::Location::Inst(inst, 1), ctx);
             }
@@ -1013,11 +1072,13 @@ impl Type for Mut {
         } else {
             if !ctx.is_const.get() {
                 lhs.comp_val = lhs.comp_val.and_then(|v| {
-                    Some(ctx.builder.build_load(
-                        self.base().llvm_type(ctx)?,
-                        v.is_pointer_value().then(|| v.into_pointer_value())?,
-                        "",
-                    ))
+                    ctx.builder
+                        .build_load(
+                            self.base().llvm_type(ctx)?,
+                            v.is_pointer_value().then(|| v.into_pointer_value())?,
+                            "",
+                        )
+                        .ok()
                 })
             }
             self.base()
@@ -1035,11 +1096,13 @@ impl Type for Mut {
     ) -> Result<Value<'src, 'ctx>, CobaltError<'src>> {
         if !ctx.is_const.get() {
             rhs.comp_val = rhs.comp_val.and_then(|v| {
-                Some(ctx.builder.build_load(
-                    self.base().llvm_type(ctx)?,
-                    v.is_pointer_value().then(|| v.into_pointer_value())?,
-                    "",
-                ))
+                ctx.builder
+                    .build_load(
+                        self.base().llvm_type(ctx)?,
+                        v.is_pointer_value().then(|| v.into_pointer_value())?,
+                        "",
+                    )
+                    .ok()
             })
         }
         self.base()
@@ -1061,7 +1124,7 @@ impl Type for Mut {
             if let (Some(llt), Some(BasicValueEnum::PointerValue(pv))) =
                 (self.base().llvm_type(ctx), val.value(ctx))
             {
-                val.comp_val = Some(ctx.builder.build_load(llt, pv, ""));
+                val.comp_val = ctx.builder.build_load(llt, pv, "").ok();
             }
         }
         self.base()._iconv_to(val, target, ctx)
@@ -1076,7 +1139,7 @@ impl Type for Mut {
             if let (Some(llt), Some(BasicValueEnum::PointerValue(pv))) =
                 (self.base().llvm_type(ctx), val.value(ctx))
             {
-                val.comp_val = Some(ctx.builder.build_load(llt, pv, ""));
+                val.comp_val = ctx.builder.build_load(llt, pv, "").ok();
             }
         }
         self.base()._econv_to(val, target, ctx)
@@ -1105,7 +1168,7 @@ impl Type for Mut {
                     val.value(ctx),
                 ) {
                     val.address = Rc::new(Cell::new(Some(pv)));
-                    Some(ctx.builder.build_load(llt, pv, ""))
+                    ctx.builder.build_load(llt, pv, "").ok()
                 } else {
                     None
                 };

--- a/cobalt-ast/src/types/mem.rs
+++ b/cobalt-ast/src/types/mem.rs
@@ -490,7 +490,7 @@ impl Type for Pointer {
                                     )
                                     .unwrap()
                             };
-                            ctx.builder.build_store(pv, v2);
+                            ctx.builder.build_store(pv, v2).unwrap();
                             val.comp_val
                         } else {
                             None
@@ -524,7 +524,7 @@ impl Type for Pointer {
                                     )
                                     .unwrap()
                             };
-                            ctx.builder.build_store(pv, v2);
+                            ctx.builder.build_store(pv, v2).unwrap();
                             val.comp_val
                         } else {
                             None
@@ -850,7 +850,7 @@ impl Type for Pointer {
                             .unwrap()
                             .into_pointer_value();
                         let v2 = unsafe { ctx.builder.build_gep(llt, v1, &[rv], "") }.unwrap();
-                        ctx.builder.build_store(lv, v2);
+                        ctx.builder.build_store(lv, v2).unwrap();
                     }
                     "-=" => {
                         let v1 = ctx
@@ -860,7 +860,7 @@ impl Type for Pointer {
                             .into_pointer_value();
                         let v2 = ctx.builder.build_int_neg(v1, "").unwrap();
                         let v3 = unsafe { ctx.builder.build_gep(llt, v2, &[rv], "") }.unwrap();
-                        ctx.builder.build_store(lv, v3);
+                        ctx.builder.build_store(lv, v3).unwrap();
                     }
                     _ => return Err(invalid_binop(&lhs, &rhs, op.0, op.1)),
                 }
@@ -892,7 +892,7 @@ impl Type for Pointer {
                             .unwrap()
                             .into_pointer_value();
                         let v2 = unsafe { ctx.builder.build_gep(llt, v1, &[rv], "") }.unwrap();
-                        ctx.builder.build_store(lv, v2);
+                        ctx.builder.build_store(lv, v2).unwrap();
                     }
                     "-=" => {
                         let v1 = ctx
@@ -902,7 +902,7 @@ impl Type for Pointer {
                             .into_pointer_value();
                         let v2 = ctx.builder.build_int_neg(v1, "").unwrap();
                         let v3 = unsafe { ctx.builder.build_gep(llt, v2, &[rv], "") }.unwrap();
-                        ctx.builder.build_store(lv, v3);
+                        ctx.builder.build_store(lv, v3).unwrap();
                     }
                     _ => return Err(invalid_binop(&lhs, &rhs, op.0, op.1)),
                 }

--- a/cobalt-ast/src/value.rs
+++ b/cobalt-ast/src/value.rs
@@ -208,7 +208,7 @@ impl<'src, 'ctx> Value<'src, 'ctx> {
             self.address.get().or_else(|| {
                 let ctv = self.value(ctx)?;
                 let alloca = ctx.builder.build_alloca(ctv.get_type(), "").ok()?;
-                ctx.builder.build_store(alloca, ctv);
+                let _ = ctx.builder.build_store(alloca, ctv);
                 self.address.set(Some(alloca));
                 Some(alloca)
             })

--- a/cobalt-ast/src/value.rs
+++ b/cobalt-ast/src/value.rs
@@ -207,7 +207,7 @@ impl<'src, 'ctx> Value<'src, 'ctx> {
         } else {
             self.address.get().or_else(|| {
                 let ctv = self.value(ctx)?;
-                let alloca = ctx.builder.build_alloca(ctv.get_type(), "");
+                let alloca = ctx.builder.build_alloca(ctv.get_type(), "").ok()?;
                 ctx.builder.build_store(alloca, ctv);
                 self.address.set(Some(alloca));
                 Some(alloca)

--- a/cobalt-build/src/cc.rs
+++ b/cobalt-build/src/cc.rs
@@ -248,9 +248,7 @@ impl CompileCommand {
                             }
                         }
                         if load {
-                            if let Some(path) = path.to_str() {
-                                inkwell::support::load_library_permanently(path);
-                            }
+                            inkwell::support::load_library_permanently(&path).unwrap();
                         }
                         self.libs.push(lib.as_ref().into());
                         None
@@ -297,9 +295,7 @@ impl CompileCommand {
                             }
                         }
                         if load {
-                            if let Some(path) = path.to_str() {
-                                inkwell::support::load_library_permanently(path);
-                            }
+                            inkwell::support::load_library_permanently(&path).unwrap();
                         }
                         self.libs.push(lib.as_ref().into());
                         None
@@ -354,9 +350,7 @@ impl CompileCommand {
                             }
                         }
                         if load {
-                            if let Some(path) = path.to_str() {
-                                inkwell::support::load_library_permanently(path);
-                            }
+                            inkwell::support::load_library_permanently(&path).unwrap();
                         }
                         self.libs.push(lib.as_ref().into());
                         None

--- a/cobalt-cli/Cargo.toml
+++ b/cobalt-cli/Cargo.toml
@@ -15,7 +15,6 @@ cobalt-build = { path = "../cobalt-build", default-features = false }
 cobalt-errors = { path = "../cobalt-errors" }
 cobalt-utils = { path = "../cobalt-utils" }
 cobalt-llvm = { path = "../cobalt-llvm", default-features = false  }
-inkwell = "0.2.0"
 toml = "0.8.4"
 temp-file = "0.1.7"
 anyhow = "1.0.75"

--- a/cobalt-cli/src/lib.rs
+++ b/cobalt-cli/src/lib.rs
@@ -5,6 +5,7 @@ use clio::{ClioPath, Input, OutputPath};
 use cobalt_ast::{CompCtx, Flags, AST};
 use cobalt_build::*;
 use cobalt_errors::*;
+use cobalt_llvm::inkwell;
 use cobalt_parser::parse_str;
 use const_format::{formatcp, str_index};
 use human_repr::*;

--- a/cobalt-llvm/Cargo.toml
+++ b/cobalt-llvm/Cargo.toml
@@ -9,7 +9,7 @@ description.workspace = true
 documentation.workspace = true
 
 [dependencies]
-inkwell = { version = "0.3.0", features = ["llvm17-0"] }
+inkwell = { version = "0.4.0", features = ["llvm17-0"] }
 llvm-sys = { version = "170", features = ["no-llvm-linking", "disable-alltargets-init"] }
 
 [build-dependencies]

--- a/cobalt-llvm/Cargo.toml
+++ b/cobalt-llvm/Cargo.toml
@@ -9,8 +9,9 @@ description.workspace = true
 documentation.workspace = true
 
 [dependencies]
-inkwell = { version = "0.2.0", features = ["llvm16-0"]}
-llvm-sys = { version = "160", features = ["no-llvm-linking", "disable-alltargets-init"]}
+inkwell = { version = "0.3.0", features = ["llvm17-0"] }
+llvm-sys = { version = "170", features = ["no-llvm-linking", "disable-alltargets-init"] }
+aya-rustc-llvm-proxy = { version = "0.9.0", optional = true }
 
 [build-dependencies]
 lazy_static = "1.4"
@@ -22,6 +23,8 @@ cc = "1.0.83"
 
 # features passed to llvm-sys
 [features]
+
+rustc-llvm = ["aya-rustc-llvm-proxy", "no-llvm-linking"]
 
 prefer-dynamic = []
 prefer-static = []

--- a/cobalt-llvm/Cargo.toml
+++ b/cobalt-llvm/Cargo.toml
@@ -11,7 +11,6 @@ documentation.workspace = true
 [dependencies]
 inkwell = { version = "0.3.0", features = ["llvm17-0"] }
 llvm-sys = { version = "170", features = ["no-llvm-linking", "disable-alltargets-init"] }
-aya-rustc-llvm-proxy = { version = "0.9.0", optional = true }
 
 [build-dependencies]
 lazy_static = "1.4"
@@ -23,8 +22,6 @@ cc = "1.0.83"
 
 # features passed to llvm-sys
 [features]
-
-rustc-llvm = ["aya-rustc-llvm-proxy", "no-llvm-linking"]
 
 prefer-dynamic = []
 prefer-static = []

--- a/cobalt-llvm/build.rs
+++ b/cobalt-llvm/build.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 #[macro_use]
 extern crate lazy_static;
 extern crate regex;


### PR DESCRIPTION
Inkwell just updated to v0.3.0. Among other things, this includes support for LLVM 17.

Update to v0.4.0!
