### PR TITLE
Add enums and unions

### DIFF
--- a/cobalt-ast/src/ast.rs
+++ b/cobalt-ast/src/ast.rs
@@ -37,7 +37,10 @@ pub trait AST<'src>: ASTClone<'src> + std::fmt::Debug {
         1
     }
     // AST properties
-    fn is_const(&self) -> bool {
+    fn is_const(&self, _ctx: &CompCtx<'src, '_>) -> bool {
+        false
+    }
+    fn has_const_call(&self, _ctx: &CompCtx<'src, '_>) -> bool {
         false
     }
     // pretty printing

--- a/cobalt-ast/src/ast/literals.rs
+++ b/cobalt-ast/src/ast/literals.rs
@@ -18,7 +18,7 @@ impl<'src> AST<'src> for IntLiteralAST<'src> {
     fn loc(&self) -> SourceSpan {
         self.loc
     }
-    fn is_const(&self) -> bool {
+    fn is_const(&self, _ctx: &CompCtx<'src, '_>) -> bool {
         true
     }
     fn codegen_impl<'ctx>(
@@ -117,7 +117,7 @@ impl<'src> AST<'src> for FloatLiteralAST<'src> {
     fn loc(&self) -> SourceSpan {
         self.loc
     }
-    fn is_const(&self) -> bool {
+    fn is_const(&self, _ctx: &CompCtx<'src, '_>) -> bool {
         true
     }
     fn codegen_impl<'ctx>(
@@ -185,7 +185,7 @@ impl<'src> AST<'src> for CharLiteralAST<'src> {
     fn loc(&self) -> SourceSpan {
         self.loc
     }
-    fn is_const(&self) -> bool {
+    fn is_const(&self, _ctx: &CompCtx<'src, '_>) -> bool {
         true
     }
     fn codegen_impl<'ctx>(
@@ -293,7 +293,7 @@ impl<'src> AST<'src> for StringLiteralAST<'src> {
     fn loc(&self) -> SourceSpan {
         self.loc
     }
-    fn is_const(&self) -> bool {
+    fn is_const(&self, _ctx: &CompCtx<'src, '_>) -> bool {
         true
     }
     fn codegen_impl<'ctx>(

--- a/cobalt-ast/src/ast/misc.rs
+++ b/cobalt-ast/src/ast/misc.rs
@@ -304,8 +304,8 @@ impl<'src> AST<'src> for ParenAST<'src> {
     fn nodes(&self) -> usize {
         self.base.nodes() + 1
     }
-    fn is_const(&self) -> bool {
-        self.base.is_const()
+    fn is_const(&self, ctx: &CompCtx<'src, '_>) -> bool {
+        self.base.is_const(ctx)
     }
     fn codegen_impl<'ctx>(
         &self,

--- a/cobalt-ast/src/ast/ops.rs
+++ b/cobalt-ast/src/ast/ops.rs
@@ -277,7 +277,9 @@ impl<'src> AST<'src> for PrefixAST<'src> {
             return Value::error();
         }
         if self.op == "&" {
-            if let Some(ty) = v.data_type.downcast::<types::Reference>() {
+            if let Ok(val) = v.data_type.pre_op(v.clone(), "&", self.loc, ctx, true) {
+                val
+            } else if let Some(ty) = v.data_type.downcast::<types::Reference>() {
                 Value {
                     data_type: types::Pointer::new(ty.base()),
                     ..v

--- a/cobalt-ast/src/ast/vars.rs
+++ b/cobalt-ast/src/ast/vars.rs
@@ -477,7 +477,7 @@ impl<'src> AST<'src> for VarDefAST<'src> {
                         Value::error()
                     }
                 }
-            } else if self.val.is_const() && self.type_.is_none() {
+            } else if self.val.is_const(ctx) && self.type_.is_none() {
                 let mut val = self.val.codegen(ctx, errs);
                 let dt = if let Some(t) = self.type_.as_ref().map(|t| {
                     let oic = ctx.is_const.replace(true);
@@ -1851,6 +1851,10 @@ impl<'src> VarGetAST<'src> {
 impl<'src> AST<'src> for VarGetAST<'src> {
     fn loc(&self) -> SourceSpan {
         self.loc
+    }
+    fn is_const<'ctx>(&self, ctx: &CompCtx<'src, '_>) -> bool {
+        ctx.lookup(&self.name, self.global)
+            .map_or(true, |v| v.0.inter_val.is_some())
     }
     fn codegen_impl<'ctx>(
         &self,

--- a/cobalt-ast/src/intrinsics.rs
+++ b/cobalt-ast/src/intrinsics.rs
@@ -48,6 +48,7 @@ pub static FUNCTION_INTRINSICS: Lazy<flurry::HashMap<&'static str, FunctionIntri
             .collect()
     });
 
+pub mod enums;
 pub mod misc;
 pub mod types;
 pub mod version;

--- a/cobalt-ast/src/intrinsics.rs
+++ b/cobalt-ast/src/intrinsics.rs
@@ -6,10 +6,21 @@ pub struct ValueIntrinsic {
     pub name: &'static str,
     pub wraps: ValueCallType,
     pub ret: fn() -> TypeRef,
+    pub is_const: bool,
 }
 impl ValueIntrinsic {
-    pub const fn new(name: &'static str, wraps: ValueCallType, ret: fn() -> TypeRef) -> Self {
-        Self { name, wraps, ret }
+    pub const fn new(
+        name: &'static str,
+        wraps: ValueCallType,
+        ret: fn() -> TypeRef,
+        is_const: bool,
+    ) -> Self {
+        Self {
+            name,
+            wraps,
+            ret,
+            is_const,
+        }
     }
 }
 
@@ -17,10 +28,15 @@ impl ValueIntrinsic {
 pub struct FunctionIntrinsic {
     pub name: &'static str,
     pub wraps: FunctionCallType,
+    pub is_const: bool,
 }
 impl FunctionIntrinsic {
-    pub const fn new(name: &'static str, wraps: FunctionCallType) -> Self {
-        Self { name, wraps }
+    pub const fn new(name: &'static str, wraps: FunctionCallType, is_const: bool) -> Self {
+        Self {
+            name,
+            wraps,
+            is_const,
+        }
     }
 }
 

--- a/cobalt-ast/src/intrinsics/enums.rs
+++ b/cobalt-ast/src/intrinsics/enums.rs
@@ -82,10 +82,10 @@ impl Type for EnumAggregator {
 }
 
 inventory::submit! {
-    ValueIntrinsic::new("enum", |_| Value::metaval(InterData::Array(vec![]), &ENUM_AGG), || &ENUM_AGG)
+    ValueIntrinsic::new("enum", |_| Value::metaval(InterData::Array(vec![]), &ENUM_AGG), || &ENUM_AGG, true)
 }
 inventory::submit! {
-    ValueIntrinsic::new("union", |_| Value::metaval(InterData::Array(vec![]), &UNION_AGG), || &UNION_AGG)
+    ValueIntrinsic::new("union", |_| Value::metaval(InterData::Array(vec![]), &UNION_AGG), || &UNION_AGG, true)
 }
 
 submit_types!(EnumAggregator);

--- a/cobalt-ast/src/intrinsics/enums.rs
+++ b/cobalt-ast/src/intrinsics/enums.rs
@@ -1,5 +1,5 @@
-use crate::types::{self, *};
 use super::*;
+use crate::types::{self, *};
 
 static ENUM_AGG: EnumAggregator = EnumAggregator(false);
 static UNION_AGG: EnumAggregator = EnumAggregator(true);
@@ -12,8 +12,12 @@ impl TypeSerde for EnumAggregator {
     impl_type_proxy!(bool, this => this.0, s => if s {&UNION_AGG} else {&ENUM_AGG});
 }
 impl Type for EnumAggregator {
-    fn size(&self) -> SizeType {SizeType::Meta}
-    fn align(&self) -> u16 {0}
+    fn size(&self) -> SizeType {
+        SizeType::Meta
+    }
+    fn align(&self) -> u16 {
+        0
+    }
     fn decay(&self) -> TypeRef {
         types::TypeData::new()
     }
@@ -28,7 +32,16 @@ impl Type for EnumAggregator {
     ) -> Result<Value<'src, 'ctx>, CobaltError<'src>> {
         if target.0 == types::TypeData::new() {
             if let Some(InterData::Array(vec)) = val.inter_val {
-                let res = vec.into_iter().map(|t| if let InterData::Type(t) = t {t} else {unreachable!()}).collect::<Vec<_>>();
+                let res = vec
+                    .into_iter()
+                    .map(|t| {
+                        if let InterData::Type(t) = t {
+                            t
+                        } else {
+                            unreachable!()
+                        }
+                    })
+                    .collect::<Vec<_>>();
                 Ok(Value::make_type(EnumOrUnion::new(res, self.0)))
             } else {
                 unreachable!()
@@ -37,7 +50,14 @@ impl Type for EnumAggregator {
             Err(cant_iconv(&val, target.0, target.1))
         }
     }
-    fn _has_bin_lhs(&self, other: TypeRef, op: &str, ctx: &CompCtx, _move_left: bool, _move_right: bool) -> bool {
+    fn _has_bin_lhs(
+        &self,
+        other: TypeRef,
+        op: &str,
+        ctx: &CompCtx,
+        _move_left: bool,
+        _move_right: bool,
+    ) -> bool {
         op == "|" && other.impl_convertible(types::TypeData::new(), ctx)
     }
     fn _bin_lhs<'src, 'ctx>(

--- a/cobalt-ast/src/intrinsics/enums.rs
+++ b/cobalt-ast/src/intrinsics/enums.rs
@@ -1,0 +1,71 @@
+use crate::types::{self, *};
+use super::*;
+
+static ENUM_AGG: EnumAggregator = EnumAggregator(false);
+static UNION_AGG: EnumAggregator = EnumAggregator(true);
+
+#[derive(Debug, Display, ConstIdentify, PartialEq, Eq, Hash)]
+#[display("<{} aggregator>", if _0 {"union"} else {"enum"})]
+struct EnumAggregator(bool);
+impl TypeSerde for EnumAggregator {
+    no_type_header!();
+    impl_type_proxy!(bool, this => this.0, s => if s {&UNION_AGG} else {&ENUM_AGG});
+}
+impl Type for EnumAggregator {
+    fn size(&self) -> SizeType {SizeType::Meta}
+    fn align(&self) -> u16 {0}
+    fn decay(&self) -> TypeRef {
+        types::TypeData::new()
+    }
+    fn _can_iconv_to(&self, other: TypeRef, _ctx: &CompCtx) -> bool {
+        other == types::TypeData::new()
+    }
+    fn _iconv_to<'src, 'ctx>(
+        &'static self,
+        val: Value<'src, 'ctx>,
+        target: (TypeRef, Option<SourceSpan>),
+        _ctx: &CompCtx<'src, 'ctx>,
+    ) -> Result<Value<'src, 'ctx>, CobaltError<'src>> {
+        if target.0 == types::TypeData::new() {
+            if let Some(InterData::Array(vec)) = val.inter_val {
+                let res = vec.into_iter().map(|t| if let InterData::Type(t) = t {t} else {unreachable!()}).collect::<Vec<_>>();
+                Ok(Value::make_type(EnumOrUnion::new(res, self.0)))
+            } else {
+                unreachable!()
+            }
+        } else {
+            Err(cant_iconv(&val, target.0, target.1))
+        }
+    }
+    fn _has_bin_lhs(&self, other: TypeRef, op: &str, ctx: &CompCtx, _move_left: bool, _move_right: bool) -> bool {
+        op == "|" && other.impl_convertible(types::TypeData::new(), ctx)
+    }
+    fn _bin_lhs<'src, 'ctx>(
+        &'static self,
+        mut lhs: Value<'src, 'ctx>,
+        rhs: Value<'src, 'ctx>,
+        op: (&'static str, SourceSpan),
+        ctx: &CompCtx<'src, 'ctx>,
+        _move_left: bool,
+        _move_right: bool,
+    ) -> Result<Value<'src, 'ctx>, CobaltError<'src>> {
+        if op.0 == "|" && rhs.data_type.impl_convertible(types::TypeData::new(), ctx) {
+            let Some(InterData::Array(vec)) = &mut lhs.inter_val else {
+                unreachable!()
+            };
+            vec.push(InterData::Type(rhs.into_type(ctx)?));
+            Ok(lhs)
+        } else {
+            Err(invalid_binop(&lhs, &rhs, op.0, op.1))
+        }
+    }
+}
+
+inventory::submit! {
+    ValueIntrinsic::new("enum", |_| Value::metaval(InterData::Array(vec![]), &ENUM_AGG), || &ENUM_AGG)
+}
+inventory::submit! {
+    ValueIntrinsic::new("union", |_| Value::metaval(InterData::Array(vec![]), &UNION_AGG), || &UNION_AGG)
+}
+
+submit_types!(EnumAggregator);

--- a/cobalt-ast/src/intrinsics/misc.rs
+++ b/cobalt-ast/src/intrinsics/misc.rs
@@ -288,8 +288,8 @@ fn alloca<'src, 'ctx>(
     }
 }
 inventory::submit! {
-    FunctionIntrinsic::new("asm", asm)
+    FunctionIntrinsic::new("asm", asm, true)
 }
 inventory::submit! {
-    FunctionIntrinsic::new("alloca", alloca)
+    FunctionIntrinsic::new("alloca", alloca, false)
 }

--- a/cobalt-ast/src/intrinsics/types.rs
+++ b/cobalt-ast/src/intrinsics/types.rs
@@ -2,7 +2,7 @@ use super::*;
 inventory::submit! {
     FunctionIntrinsic::new("type", |v, c, a, _| {
         extract_single("@type", v, c, a).map(|v| Value::make_type(v.data_type))
-    })
+    }, true)
 }
 inventory::submit! {
     FunctionIntrinsic::new("size", |v, c, a, ctx| {
@@ -14,7 +14,7 @@ inventory::submit! {
                 )
             })
         })
-    })
+    }, true)
 }
 inventory::submit! {
     FunctionIntrinsic::new("sized", |v, c, a, ctx| {
@@ -30,7 +30,7 @@ inventory::submit! {
                 )
             })
         })
-    })
+    }, true)
 }
 inventory::submit! {
     FunctionIntrinsic::new("align", |v, c, a, ctx| {
@@ -42,7 +42,7 @@ inventory::submit! {
                 )
             })
         })
-    })
+    }, true)
 }
 inventory::submit! {
     FunctionIntrinsic::new("typename", |v, c, a, ctx| {
@@ -50,7 +50,7 @@ inventory::submit! {
             v.into_type(ctx)
                 .map(|t| Value::make_str(t.to_string(), ctx))
         })
-    })
+    }, true)
 }
 fn extract_single<'src, 'ctx>(
     name: &'static str,

--- a/cobalt-ast/src/intrinsics/version.rs
+++ b/cobalt-ast/src/intrinsics/version.rs
@@ -11,7 +11,8 @@ inventory::submit! {
             InterData::Int(*VERSION_MAJOR as _),
             types::IntLiteral::new(),
         ),
-        || types::IntLiteral::new()
+        || types::IntLiteral::new(),
+        true
     )
 }
 inventory::submit! {
@@ -21,7 +22,8 @@ inventory::submit! {
             InterData::Int(*VERSION_MINOR as _),
             types::IntLiteral::new(),
         ),
-        || types::IntLiteral::new()
+        || types::IntLiteral::new(),
+        true
     )
 }
 inventory::submit! {
@@ -31,14 +33,16 @@ inventory::submit! {
             InterData::Int(*VERSION_PATCH as _),
             types::IntLiteral::new(),
         ),
-        || types::IntLiteral::new()
+        || types::IntLiteral::new(),
+        true
     )
 }
 inventory::submit! {
     ValueIntrinsic::new(
         "version_string",
         |ctx| Value::make_str(env!("CARGO_PKG_VERSION"), ctx),
-        || types::SizedArray::new(types::Int::unsigned(8), env!("CARGO_PKG_VERSION").len() as _)
+        || types::SizedArray::new(types::Int::unsigned(8), env!("CARGO_PKG_VERSION").len() as _),
+        true
     )
 }
 inventory::submit! {
@@ -56,7 +60,8 @@ inventory::submit! {
                 .into_iter()
                 .collect(),
             )
-        }
+        },
+        true
     )
 }
 fn make_version<'src, 'ctx>(ctx: &CompCtx<'src, 'ctx>) -> Value<'src, 'ctx> {

--- a/cobalt-ast/src/types.rs
+++ b/cobalt-ast/src/types.rs
@@ -155,6 +155,8 @@ impl<T: NullType> TypeSerde for T {
         Self::create_self()
     }
 }
+
+#[macro_export]
 macro_rules! no_type_header {
     () => {
         type Header = ();
@@ -162,9 +164,11 @@ macro_rules! no_type_header {
             false
         }
         fn get_header() -> Self::Header {}
-        fn set_header(header: Self::Header) {}
+        fn set_header(_header: Self::Header) {}
     };
 }
+
+#[macro_export]
 macro_rules! impl_null_type_with_new {
     ($ty:ty) => {
         impl NullType for $ty {
@@ -174,6 +178,8 @@ macro_rules! impl_null_type_with_new {
         }
     };
 }
+
+#[macro_export]
 macro_rules! impl_type_proxy {
     ($proxy:ty, $gp:pat => $ge:expr, $sp:pat => $se:expr) => {
         type Proxy = $proxy;
@@ -753,6 +759,7 @@ pub struct TypeLoader {
     pub load_header: fn(&mut dyn erased_serde::Deserializer) -> Result<(), erased_serde::Error>,
     pub load: fn(&mut dyn erased_serde::Deserializer) -> Result<TypeRef, erased_serde::Error>,
 }
+
 #[macro_export]
 macro_rules! type_loader {
     ($T:ty) => {
@@ -769,6 +776,8 @@ macro_rules! type_loader {
         }
     };
 }
+
+#[macro_export]
 macro_rules! submit_types {
     ($T:ty) => (
         inventory::submit! {type_loader!($T)}
@@ -815,6 +824,7 @@ pub static TYPE_SERIAL_REGISTRY: Lazy<flurry::HashMap<u64, LoadInfo>> =
 
 pub mod agg;
 pub mod custom;
+pub mod enums;
 pub mod float;
 pub mod func;
 pub mod int;
@@ -824,6 +834,7 @@ pub mod meta;
 
 pub use agg::*;
 pub use custom::*;
+pub use enums::*;
 pub use float::*;
 pub use func::*;
 pub use int::*;

--- a/cobalt-ast/src/types.rs
+++ b/cobalt-ast/src/types.rs
@@ -673,6 +673,14 @@ pub trait Type:
             self.as_type_ref()
         })
     }
+
+    fn add_ptr(&'static self, is_mut: bool) -> TypeRef {
+        types::Pointer::new(if is_mut {
+            types::Mut::new(self.as_type_ref())
+        } else {
+            self.as_type_ref()
+        })
+    }
 }
 impl dyn Type {
     pub fn is<T: ConcreteType>(&self) -> bool {

--- a/cobalt-ast/src/types.rs
+++ b/cobalt-ast/src/types.rs
@@ -37,6 +37,9 @@ impl SizeType {
             self
         }
     }
+    pub fn is_c(self) -> bool {
+        !matches!(self, Static(0) | Dynamic | Meta)
+    }
 }
 impl Display for SizeType {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {

--- a/cobalt-ast/src/types/custom.rs
+++ b/cobalt-ast/src/types/custom.rs
@@ -3,11 +3,14 @@ use once_cell::sync::Lazy;
 use serde::de::DeserializeSeed;
 use std::marker::PhantomData;
 use std::{cell::Ref, collections::HashMap};
+
 static CUSTOM_INTERN: Interner<Box<str>> = Interner::new();
 static CUSTOM_DATA: Lazy<
     flurry::HashMap<&'static str, (TypeRef, bool, flurry::HashMap<Box<str>, usize>, usize)>,
 > = Lazy::new(flurry::HashMap::new);
+
 pub type ValueRef<'a, 'src, 'ctx> = Ref<'a, Value<'src, 'ctx>>;
+
 #[derive(Debug, ConstIdentify, Display, RefCastCustom)]
 #[repr(transparent)]
 pub struct Custom(Box<str>);
@@ -129,6 +132,7 @@ impl Custom {
             });
     }
 }
+
 #[derive(DeserializeState)]
 #[serde(de_parameters = "'a")]
 #[serde(deserialize_state = "&'a CompCtx<'src, 'ctx>")]

--- a/cobalt-ast/src/types/enums.rs
+++ b/cobalt-ast/src/types/enums.rs
@@ -1,0 +1,76 @@
+use super::*;
+use std::cmp::Ordering;
+use std::fmt::{self, Display, Formatter};
+
+
+#[derive(Debug, ConstIdentify, PartialEq, Eq, Hash, RefCastCustom)]
+#[repr(transparent)]
+pub struct EnumOrUnion((Box<[TypeRef]>, bool));
+impl EnumOrUnion {
+    #[ref_cast_custom]
+    fn from_ref(variants: &(Box<[TypeRef]>, bool)) -> &Self;
+
+    pub fn sort_types(lhs: &TypeRef, rhs: &TypeRef) -> Ordering {
+        todo!()
+    }
+
+    pub fn new<V: Into<Box<[TypeRef]>>>(variants: V, sorted: bool) -> &'static Self {
+        static INTERN: Interner<(Box<[TypeRef]>, bool)> = Interner::new();
+        let mut vars = variants.into();
+        if sorted {
+            vars.sort_by(Self::sort_types);
+        }
+        Self::from_ref(INTERN.intern((vars, sorted)))
+    }
+
+    pub fn variants(&self) -> &[TypeRef] {
+        &self.0.0
+    }
+
+    pub fn is_sorted(&self) -> bool {
+        self.0.1
+    }
+}
+impl Display for EnumOrUnion {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(if self.0.1 {"@union"} else {"@enum"})?;
+        for item in self.0.0.iter() {
+            f.write_str(" | ")?;
+            Display::fmt(&item, f)?;
+        }
+        Ok(())
+    }
+}
+
+#[doc(hidden)]
+#[derive(Serialize, Deserialize)]
+pub struct EoUShim {
+    sorted: bool,
+    variants: Cow<'static, [TypeRef]>,
+}
+
+impl TypeSerde for EnumOrUnion {
+    no_type_header!();
+    impl_type_proxy!(EoUShim, this => EoUShim {sorted: this.is_sorted(), variants: this.variants().into()}, EoUShim {sorted, variants} => Self::new(variants, sorted));
+}
+impl Type for EnumOrUnion {
+    fn size(&self) -> SizeType {
+        tuple_size(self.variants())
+    }
+    fn align(&self) -> u16 {
+        self.variants()
+            .iter()
+            .map(|v| v.align())
+            .fold(1, |old, new| {
+                if old == 0 || new == 0 {
+                    0
+                } else {
+                    std::cmp::max(old, new)
+                }
+            })
+    }
+}
+
+pub type Enum = EnumOrUnion;
+pub type Union = EnumOrUnion;
+submit_types!(EnumOrUnion);

--- a/cobalt-ast/src/types/enums.rs
+++ b/cobalt-ast/src/types/enums.rs
@@ -129,7 +129,7 @@ impl EnumOrUnion {
             types::Null::new() // TODO: switch this to a never type
         } else {
             types::Int::unsigned(
-                (usize::BITS - self.variants().len().leading_zeros() as u32 - 1) as u16,
+                (usize::BITS - self.variants().len().leading_zeros() - 1) as u16,
             )
         }
     }

--- a/cobalt-ast/src/types/enums.rs
+++ b/cobalt-ast/src/types/enums.rs
@@ -108,15 +108,15 @@ impl EnumOrUnion {
     #[ref_cast_custom]
     fn from_ref(variants: &(Box<[TypeRef]>, bool)) -> &Self;
 
-    pub fn sort_types(lhs: &TypeRef, rhs: &TypeRef) -> Ordering {
-        todo!()
-    }
-
     pub fn new<V: Into<Box<[TypeRef]>>>(variants: V, sorted: bool) -> &'static Self {
         static INTERN: Interner<(Box<[TypeRef]>, bool)> = Interner::new();
         let mut vars = variants.into();
         if sorted {
-            vars.sort_by(Self::sort_types);
+            let mut names = vars.iter().map(|t| (t.to_string(), t)).collect::<Vec>();
+            names.sort_by_key(|t| &t.0);
+            // clear then extend avoids a re-allocation
+            vars.clear();
+            vars.extend(names.into_iter().map(|t| t.1));
         }
         Self::from_ref(INTERN.intern((vars, sorted)))
     }

--- a/cobalt-ast/src/types/enums.rs
+++ b/cobalt-ast/src/types/enums.rs
@@ -128,9 +128,7 @@ impl EnumOrUnion {
         if self.variants().is_empty() {
             types::Null::new() // TODO: switch this to a never type
         } else {
-            types::Int::unsigned(
-                (usize::BITS - self.variants().len().leading_zeros() - 1) as u16,
-            )
+            types::Int::unsigned((usize::BITS - self.variants().len().leading_zeros() - 1) as u16)
         }
     }
 }

--- a/cobalt-ast/src/types/enums.rs
+++ b/cobalt-ast/src/types/enums.rs
@@ -2,7 +2,6 @@ use super::*;
 use std::cmp::Ordering;
 use std::fmt::{self, Display, Formatter};
 
-
 #[derive(Debug, ConstIdentify, PartialEq, Eq, Hash, RefCastCustom)]
 #[repr(transparent)]
 pub struct EnumOrUnion((Box<[TypeRef]>, bool));
@@ -24,17 +23,17 @@ impl EnumOrUnion {
     }
 
     pub fn variants(&self) -> &[TypeRef] {
-        &self.0.0
+        &self.0 .0
     }
 
     pub fn is_sorted(&self) -> bool {
-        self.0.1
+        self.0 .1
     }
 }
 impl Display for EnumOrUnion {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.write_str(if self.0.1 {"@union"} else {"@enum"})?;
-        for item in self.0.0.iter() {
+        f.write_str(if self.0 .1 { "@union" } else { "@enum" })?;
+        for item in self.0 .0.iter() {
             f.write_str(" | ")?;
             Display::fmt(&item, f)?;
         }

--- a/cobalt-ast/src/types/enums.rs
+++ b/cobalt-ast/src/types/enums.rs
@@ -127,7 +127,7 @@ impl EnumOrUnion {
     pub fn tag_type(&self) -> TypeRef {
         match self.variants().len() {
             0 | 1 => types::Null::new(),
-            c => types::Int::unsigned((usize::BITS - c.leading_zeros() - 1) as _),
+            c => types::Int::unsigned((usize::BITS - (c - 1).leading_zeros()) as _),
         }
     }
 }

--- a/cobalt-ast/src/types/enums.rs
+++ b/cobalt-ast/src/types/enums.rs
@@ -1,5 +1,4 @@
 use super::*;
-use std::cmp::Ordering;
 use std::fmt::{self, Display, Formatter};
 
 #[inline(always)]
@@ -112,11 +111,7 @@ impl EnumOrUnion {
         static INTERN: Interner<(Box<[TypeRef]>, bool)> = Interner::new();
         let mut vars = variants.into();
         if sorted {
-            let mut names = vars.iter().map(|t| (t.to_string(), t)).collect::<Vec>();
-            names.sort_by_key(|t| &t.0);
-            // clear then extend avoids a re-allocation
-            vars.clear();
-            vars.extend(names.into_iter().map(|t| t.1));
+            vars.sort_by_cached_key(ToString::to_string);
         }
         Self::from_ref(INTERN.intern((vars, sorted)))
     }

--- a/cobalt-ast/src/types/float.rs
+++ b/cobalt-ast/src/types/float.rs
@@ -1,5 +1,6 @@
 use super::*;
 use inkwell::FloatPredicate::*;
+
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Display, Serialize, Deserialize,
 )]
@@ -13,10 +14,12 @@ pub enum FPType {
     #[display(fmt = "f128")]
     F128,
 }
+
 static F16: Float = Float(FPType::F16);
 static F32: Float = Float(FPType::F32);
 static F64: Float = Float(FPType::F64);
 static F128: Float = Float(FPType::F128);
+
 #[derive(Debug, ConstIdentify, Display)]
 pub struct Float(FPType);
 impl Float {
@@ -1489,4 +1492,5 @@ impl Type for Float {
         }
     }
 }
+
 submit_types!(Float);

--- a/cobalt-ast/src/types/func.rs
+++ b/cobalt-ast/src/types/func.rs
@@ -1,4 +1,5 @@
 use super::*;
+
 #[derive(Debug, ConstIdentify, RefCastCustom)]
 #[repr(transparent)]
 pub struct Function((TypeRef, Box<[(TypeRef, bool)]>));
@@ -225,6 +226,7 @@ impl Type for Function {
         ))
     }
 }
+
 #[derive(Debug, ConstIdentify, RefCastCustom)]
 #[repr(transparent)]
 pub struct BoundMethod((TypeRef, Box<[(TypeRef, bool)]>));
@@ -399,4 +401,5 @@ impl TypeSerde for BoundMethod {
         FnProxy { ret, params } => Self::new(ret, unsafe {std::mem::transmute::<_, &[(TypeRef, bool)]>(&*params)})
     );
 }
+
 submit_types!(Function, BoundMethod);

--- a/cobalt-ast/src/types/int.rs
+++ b/cobalt-ast/src/types/int.rs
@@ -50,7 +50,7 @@ impl Type for Int {
         SizeType::Static(((self.0 .0 + 7) / 8) as _)
     }
     fn align(&self) -> u16 {
-        1 << std::cmp::min(16 - self.0 .0.leading_zeros(), 6)
+        1 << (15 - std::cmp::min(self.0 .0.leading_zeros(), 15)).clamp(3, 6) - 3
     }
     fn llvm_type<'ctx>(&self, ctx: &CompCtx<'_, 'ctx>) -> Option<BasicTypeEnum<'ctx>> {
         Some(ctx.context.custom_width_int_type(self.bits() as _).into())

--- a/cobalt-ast/src/types/int.rs
+++ b/cobalt-ast/src/types/int.rs
@@ -22,7 +22,7 @@ impl Int {
         Self::new(ctx.flags.word_size, false)
     }
     pub fn usize(ctx: &CompCtx) -> &'static Self {
-        Self::new(ctx.flags.word_size, false)
+        Self::new(ctx.flags.word_size, true)
     }
     pub fn bool() -> &'static Self {
         Self::new(1, true)

--- a/cobalt-ast/src/types/int.rs
+++ b/cobalt-ast/src/types/int.rs
@@ -1,5 +1,6 @@
 use super::*;
 use inkwell::IntPredicate::*;
+
 #[derive(Debug, ConstIdentify, PartialEq, Eq, Hash, Display, RefCastCustom)]
 #[display(fmt = "{}{}", r#"if _0.1 {"u"} else {"i"}"#, "_0.0")]
 #[repr(transparent)]
@@ -1944,6 +1945,7 @@ impl Type for Int {
         }
     }
 }
+
 #[derive(Debug, ConstIdentify, Display)]
 #[display(fmt = "<int literal>")]
 pub struct IntLiteral(());
@@ -2281,4 +2283,5 @@ impl Type for IntLiteral {
         }
     }
 }
+
 submit_types!(Int, IntLiteral);

--- a/cobalt-ast/src/types/int.rs
+++ b/cobalt-ast/src/types/int.rs
@@ -50,7 +50,7 @@ impl Type for Int {
         SizeType::Static(((self.0 .0 + 7) / 8) as _)
     }
     fn align(&self) -> u16 {
-        1 << (15 - std::cmp::min(self.0 .0.leading_zeros(), 15)).clamp(3, 6) - 3
+        1 << ((15 - std::cmp::min(self.0 .0.leading_zeros(), 15)).clamp(3, 6) - 3)
     }
     fn llvm_type<'ctx>(&self, ctx: &CompCtx<'_, 'ctx>) -> Option<BasicTypeEnum<'ctx>> {
         Some(ctx.context.custom_width_int_type(self.bits() as _).into())

--- a/cobalt-ast/src/types/intrinsic.rs
+++ b/cobalt-ast/src/types/intrinsic.rs
@@ -1,5 +1,7 @@
 use super::*;
+
 static INTRINSIC_INTERN: Interner<Box<str>> = Interner::new();
+
 #[derive(Debug, ConstIdentify, Display, RefCastCustom)]
 #[repr(transparent)]
 #[display(fmt = "@{_0}")]
@@ -238,7 +240,9 @@ impl Type for Intrinsic {
             })
     }
 }
+
 static ASM_INTERN: Interner<TypeRef> = Interner::new();
+
 #[derive(Debug, ConstIdentify, Display, RefCastCustom)]
 #[repr(transparent)]
 #[display(fmt = "@asm({_0})")]
@@ -343,4 +347,5 @@ impl Type for InlineAsm {
         }
     }
 }
+
 submit_types!(Intrinsic, InlineAsm);

--- a/cobalt-ast/src/types/mem.rs
+++ b/cobalt-ast/src/types/mem.rs
@@ -2,6 +2,7 @@ use super::*;
 use inkwell::IntPredicate::*;
 use std::cell::Cell;
 use std::rc::Rc;
+
 #[derive(Debug, ConstIdentify, Display, RefCastCustom)]
 #[display(fmt = "&{}", _0)]
 #[repr(transparent)]
@@ -404,6 +405,7 @@ impl Type for Reference {
         self.base().subscript(val, idx, ctx)
     }
 }
+
 #[derive(Debug, ConstIdentify, Display, RefCastCustom)]
 #[display(fmt = "*{}", _0)]
 #[repr(transparent)]
@@ -946,6 +948,7 @@ impl Type for Pointer {
         self.base().ptr_type(ctx)
     }
 }
+
 #[derive(Debug, ConstIdentify, Display, RefCastCustom)]
 #[display(fmt = "mut {}", _0)]
 #[repr(transparent)]
@@ -1204,4 +1207,5 @@ impl Type for Mut {
         self.base()._has_refmut_attr(attr, ctx)
     }
 }
+
 submit_types!(Reference, Pointer, Mut);

--- a/cobalt-ast/src/value.rs
+++ b/cobalt-ast/src/value.rs
@@ -42,6 +42,7 @@ pub enum InterData<'src, 'ctx> {
     Function(#[serde(deserialize_state)] FnData<'src, 'ctx>),
     InlineAsm(String, String),
     Type(TypeRef),
+    Spanned(SourceSpan, #[serde(deserialize_state)] Box<Self>),
     Module(
         #[serde(deserialize_state)] HashMap<Cow<'src, str>, Symbol<'src, 'ctx>>,
         Vec<(CompoundDottedName<'src>, bool)>,

--- a/cobalt-errors/src/error.rs
+++ b/cobalt-errors/src/error.rs
@@ -187,6 +187,15 @@ pub enum CobaltError<'src> {
         #[label("error at byte {pos} of glob: {msg}")]
         loc: SourceSpan,
     },
+    #[error("Duplicate {} variants", if *.is_union {"union"} else {"enum"})]
+    DuplicateEnumVariant {
+        is_union: bool,
+        #[label("previously defined here")]
+        prev: SourceSpan,
+        #[label("redefinition of variant {ty}")]
+        curr: SourceSpan,
+        ty: String,
+    },
     #[error("value cannot be determined at compile-time")]
     NotCompileTime {
         #[label]


### PR DESCRIPTION
These are *tagged* enums and unions. They're basically the same, the only difference is that unions have a sorted order, so `@union | a | b` and `@union | b | a` are the same type, while `@enum | a | b` and `@enum | b | a` are not.
These take place at the type level, and are made to be used with symbols. For example, a unit enum can be created like this:
```
const my_unit_enum = @enum
| $value1
| $value2
| $value3;
```
With this, enums with fields can also be created:
```
const my_field_enum = @enum
| ($int, i64)
| ($float, f64);
```
